### PR TITLE
fix(chat): guard Enter handlers against IME composition (#71)

### DIFF
--- a/media/chat.js
+++ b/media/chat.js
@@ -1652,7 +1652,7 @@
     if (popVisible){
       if (e.key === "ArrowDown"){ e.preventDefault(); movePop(1); return; }
       if (e.key === "ArrowUp")  { e.preventDefault(); movePop(-1); return; }
-      if (e.key === "Tab" || e.key === "Enter"){
+      if (e.key === "Tab" || (e.key === "Enter" && !e.isComposing)){
         e.preventDefault(); applyPop(); return;
       }
       if (e.key === "Escape"){ e.preventDefault(); hidePop(); return; }

--- a/media/chat.js
+++ b/media/chat.js
@@ -1678,7 +1678,7 @@
       cbt && cbt.click();
       return;
     }
-    if (e.key === "Enter" && !e.shiftKey){ e.preventDefault(); doSend(); }
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing){ e.preventDefault(); doSend(); }
     else if (e.key === "Escape" && busy){ e.preventDefault(); _stopping = true; if (_dcSpinner) _dcSpinner.classList.add("stopping"); vscode.postMessage({type:"stop"}); }
   });
   sbtn.addEventListener("click", doSend);
@@ -2411,7 +2411,7 @@
       else renderSessions();
     }
     inp.addEventListener("keydown", function(e){
-      if (e.key === "Enter"){ e.preventDefault(); commit(); }
+      if (e.key === "Enter" && !e.isComposing){ e.preventDefault(); commit(); }
       else if (e.key === "Escape"){ e.preventDefault(); committed = true; renderSessions(); }
     });
     inp.addEventListener("blur", commit);
@@ -2532,7 +2532,7 @@
     btnCancel.addEventListener("click", function(){ exitEditMode(msgU, false); });
     ta.addEventListener("keydown", function(e){
       if (e.key === "Escape"){ e.preventDefault(); exitEditMode(msgU, false); return; }
-      if (e.key === "Enter" && !e.shiftKey){ e.preventDefault(); submitEdit(msgU); return; }
+      if (e.key === "Enter" && !e.shiftKey && !e.isComposing){ e.preventDefault(); submitEdit(msgU); return; }
     });
   }
   function exitEditMode(msgU, keepText){


### PR DESCRIPTION
## 问题

在使用中文输入法（拼音/五笔等）时，按下回车键确认选字会同时触发插件的「发送消息」行为，导致用户在还未输完内容时就意外提交。

复现：打开聊天输入框 → 切到中文输入法 → 输入拼音弹出候选 → 按 Enter 选字 → 消息被意外发送。

## 根因

`media/chat.js` 中三处 `keydown` 监听器未检查 `e.isComposing`：

- 主输入框发送（`doSend`）
- 会话重命名输入框（`commit`）
- 消息编辑模式（`submitEdit`）

当输入法正在合成文字时 `KeyboardEvent.isComposing === true`，此时不应触发上述操作。

## 修复

三处 Enter 判断加 `&& !e.isComposing`。VS Code Webview 原生支持 `isComposing`，无需 polyfill。

## 影响范围

所有使用 IME 输入法的用户（中文、日文、韩文等）。无功能性改动。

Closes #71