### PR TITLE
fix(session-store): heal orphan tool messages causing HTTP 400 (#70)

### DIFF
--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -79,7 +79,12 @@ class SessionStore {
     /** Return persisted API-format messages for cross-turn context restore. */
     loadApiMessages(sid) {
         const s = this.all().find(x => x.id === sid);
-        return (s && Array.isArray(s.apiMessages)) ? s.apiMessages : [];
+        if (!s || !Array.isArray(s.apiMessages)) return [];
+        // Self-heal legacy sessions: skip any orphan `tool` messages at the
+        // start (they would otherwise trigger HTTP 400 — see issue #70).
+        let i = 0;
+        while (i < s.apiMessages.length && s.apiMessages[i].role === 'tool') i++;
+        return i > 0 ? s.apiMessages.slice(i) : s.apiMessages;
     }
 
     /**
@@ -122,7 +127,18 @@ class SessionStore {
                 const { reasoning_content, ...rest } = m; // eslint-disable-line no-unused-vars
                 return rest;
             }) : [];
-            s.apiMessages = stripped.length > MAX_API ? stripped.slice(-MAX_API) : stripped;
+            // Truncate to the last MAX_API messages, but never start with an
+            // orphan `tool` message — DeepSeek requires every tool message to
+            // follow its assistant{tool_calls}. See issue #70.
+            if (stripped.length > MAX_API) {
+                let startIdx = stripped.length - MAX_API;
+                while (startIdx < stripped.length && stripped[startIdx].role === 'tool') {
+                    startIdx++;
+                }
+                s.apiMessages = stripped.slice(startIdx);
+            } else {
+                s.apiMessages = stripped;
+            }
         }
 
         const last = s.messages[s.messages.length - 1];


### PR DESCRIPTION
## 问题

长会话（工具调用频繁、API 消息数 > 200）重新发送消息时，偶发 HTTP 400：

```
DeepSeek API 400: {"error":{"message":"Messages with role 'tool' must be a response to a preceding message with 'tool_calls'","type":"invalid_request_error",...}}
```

UI 提示「请求参数错误，可能是上下文过长或消息格式异常」。

## 根因

`src/chat/session-store.js` 的 `append()` 旧逻辑：

```js
s.apiMessages = stripped.length > MAX_API ? stripped.slice(-MAX_API) : stripped;
```

当 `stripped.length > 200` 时，`slice(-200)` 的切割点可能正好落在 `assistant{tool_calls}` / `tool` 配对的中间：

```
... [assistant{tool_calls}]  ← 被截掉
    [tool]                   ← 成为第一条消息（孤立！）
    [tool]
    [user]
```

下次加载会话时，孤立的 `tool` 消息作为 API 历史起始消息发送给 DeepSeek，触发 HTTP 400。

## 修复

双重保护：

1. **保存时**（`append`）：截断后若首条为 `tool`，向后移动起点直到找到合法的非 `tool` 消息。
2. **加载时**（`loadApiMessages`）：对已存储的损坏会话做自愈，跳过开头所有孤立 `tool` 消息。

保存层防止新数据损坏，加载层修复已损坏的旧数据。

## 影响范围

- `src/chat/session-store.js` 单文件改动，18 行新增 / 2 行删除
- 仅在会话 API 消息数 > 200 时触发（工具调用频繁的长会话）
- 短会话与新建会话无影响

Closes #70
