### PR TITLE
fix(shell): hung-process heartbeat + hard timeout cap (#69)

### DIFF
--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -65,12 +65,12 @@ const TOOL_DEFS = [
         type: 'function',
         function: {
             name: 'run_shell',
-            description: 'Execute a shell command in the workspace root. Use ONLY for things that genuinely need a shell: package managers (npm/pip/cargo), build tools, git, test runners, system info. Do NOT use to read, write, list, or search files — use the dedicated read_file / write_file / list_dir / grep_search tools instead.',
+            description: 'Execute a shell command in the workspace root. Use ONLY for things that genuinely need a shell: package managers (npm/pip/cargo), build tools, git, test runners, system info. Do NOT use to read, write, list, or search files — use the dedicated read_file / write_file / list_dir / grep_search tools instead. If the result contains "[Note: no output for last …s]" or "[Note: process was silent for last …s before timeout]", the process is hung (port in use, waiting for input, blocked on external resource) — stop and report the situation to the user instead of retrying.',
             parameters: {
                 type: 'object',
                 properties: {
                     command: { type: 'string', description: 'Shell command to execute.' },
-                    timeout_ms: { type: 'integer', description: 'Timeout in milliseconds (default 30000).' },
+                    timeout_ms: { type: 'integer', description: 'Timeout in milliseconds (default 30000, hard capped at 300000 = 5 min).' },
                 },
                 required: ['command'],
             },

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -65,7 +65,7 @@ const TOOL_DEFS = [
         type: 'function',
         function: {
             name: 'run_shell',
-            description: 'Execute a shell command in the workspace root. Use ONLY for things that genuinely need a shell: package managers (npm/pip/cargo), build tools, git, test runners, system info. Do NOT use to read, write, list, or search files — use the dedicated read_file / write_file / list_dir / grep_search tools instead. If the result contains "[Note: no output for last …s]" or "[Note: process was silent for last …s before timeout]", the process is hung (port in use, waiting for input, blocked on external resource) — stop and report the situation to the user instead of retrying.',
+            description: 'Execute a shell command in the workspace root. Use ONLY for things that genuinely need a shell: package managers (npm/pip/cargo), build tools, git, test runners, system info. Do NOT use to read, write, list, or search files — use the dedicated read_file / write_file / list_dir / grep_search tools instead. If the result contains "[Note: no output for last …s]" or "[Note: process was silent for last …s before timeout]", the process may be hung or stalled (e.g. port in use, waiting for input, blocked on external resource) — do NOT retry blindly; verify the cause (check port usage, add verbose flags, etc.) or report the situation to the user.',
             parameters: {
                 type: 'object',
                 properties: {

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -75,7 +75,13 @@ async function toolRunShell(args, ctx = {}) {
     const MAX_BUF       = 10 * 1024 * 1024;
     const MAX_TIMEOUT_MS = 300_000;                                         // 5 min hard cap — issue #69
     const STALL_PROBE_MS = 15_000;                                          // heartbeat every 15s when no output
-    const requestedTimeout = args.timeout_ms || 30000;
+    const KILL_GRACE_MS  = 5_000;                                           // SIGTERM → SIGKILL grace period — issue #69 follow-up
+    // Normalize args.timeout_ms: tolerate strings, NaN, negatives, etc.
+    // Falls back to 30000ms default, clamps to (0, MAX_TIMEOUT_MS].
+    const requestedRaw = Number(args.timeout_ms);
+    const requestedTimeout = (Number.isFinite(requestedRaw) && requestedRaw > 0)
+        ? requestedRaw
+        : 30000;
     const timeoutMs     = Math.min(requestedTimeout, MAX_TIMEOUT_MS);
     const onStreamDelta = typeof ctx.onStreamDelta === 'function' ? ctx.onStreamDelta : null;
     const abortSignal   = ctx.abortSignal;
@@ -117,6 +123,17 @@ async function toolRunShell(args, ctx = {}) {
         const timer = setTimeout(() => {
             killedByTimeout = true;
             try { proc.kill('SIGTERM'); } catch {}
+            // If the process ignores SIGTERM (or kill() failed), escalate
+            // to SIGKILL after a short grace period and force-settle so
+            // run_shell can never hang indefinitely.
+            setTimeout(() => {
+                if (settled) return;
+                try { proc.kill('SIGKILL'); } catch {}
+                // Last-resort settle in case 'close' never fires.
+                setTimeout(() => {
+                    if (!settled) settle(truncate(`Error: command timed out after ${timeoutMs}ms and did not terminate after SIGTERM+SIGKILL`));
+                }, 1000);
+            }, KILL_GRACE_MS);
         }, timeoutMs);
 
         // Stall heartbeat: when the process produces no output for STALL_PROBE_MS,

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -73,7 +73,10 @@ async function toolRunShell(args, ctx = {}) {
     }
 
     const MAX_BUF       = 10 * 1024 * 1024;
-    const timeoutMs     = args.timeout_ms || 30000;
+    const MAX_TIMEOUT_MS = 300_000;                                         // 5 min hard cap — issue #69
+    const STALL_PROBE_MS = 15_000;                                          // heartbeat every 15s when no output
+    const requestedTimeout = args.timeout_ms || 30000;
+    const timeoutMs     = Math.min(requestedTimeout, MAX_TIMEOUT_MS);
     const onStreamDelta = typeof ctx.onStreamDelta === 'function' ? ctx.onStreamDelta : null;
     const abortSignal   = ctx.abortSignal;
 
@@ -94,11 +97,13 @@ async function toolRunShell(args, ctx = {}) {
         let killedByTimeout = false;
         let killedByAbort   = false;
         let settled         = false;
+        let lastOutputAt    = Date.now();                                   // for stall heartbeat — issue #69
 
         const settle = (val) => {
             if (settled) return;
             settled = true;
             clearTimeout(timer);
+            clearInterval(stallTimer);
             if (abortSignal && onAbort) {
                 try { abortSignal.removeEventListener('abort', onAbort); } catch {}
             }
@@ -109,6 +114,17 @@ async function toolRunShell(args, ctx = {}) {
             killedByTimeout = true;
             try { proc.kill('SIGTERM'); } catch {}
         }, timeoutMs);
+
+        // Stall heartbeat: when the process produces no output for STALL_PROBE_MS,
+        // push a synthetic notice through onStreamDelta so the webview tail shows
+        // "still alive but silent" and the user knows where things are stuck.
+        const stallTimer = setInterval(() => {
+            if (settled) return;
+            const silentMs = Date.now() - lastOutputAt;
+            if (silentMs >= STALL_PROBE_MS && onStreamDelta) {
+                try { onStreamDelta(`\n[Note: no output for last ${Math.round(silentMs / 1000)}s]\n`); } catch {}
+            }
+        }, STALL_PROBE_MS);
 
         const onAbort = () => {
             killedByAbort = true;
@@ -131,6 +147,7 @@ async function toolRunShell(args, ctx = {}) {
                 else                  stderrBuf += txt;
                 combinedSize += txt.length;
             }
+            lastOutputAt = Date.now();
             if (onStreamDelta) {
                 try { onStreamDelta(txt); } catch {}
             }
@@ -145,7 +162,13 @@ async function toolRunShell(args, ctx = {}) {
             const stdout = stdoutBuf.replace(/\s+$/, '');
             const stderr = stderrBuf.replace(/\s+$/, '');
             if (killedByAbort)   return settle('Error: aborted by user');
-            if (killedByTimeout) return settle(truncate(`Error: command timed out after ${timeoutMs}ms\n${stdout}${stderr ? '\n--- stderr ---\n' + stderr : ''}`));
+            if (killedByTimeout) {
+                const silentMs = Date.now() - lastOutputAt;
+                const stallNote = silentMs >= STALL_PROBE_MS
+                    ? `\n[Note: process was silent for last ${Math.round(silentMs / 1000)}s before timeout — likely hung (e.g. port in use, waiting for input, blocked on external resource). Do NOT retry blindly; report the situation to the user.]`
+                    : '';
+                return settle(truncate(`Error: command timed out after ${timeoutMs}ms${stallNote}\n${stdout}${stderr ? '\n--- stderr ---\n' + stderr : ''}`));
+            }
             const exitCode = (code == null && signal) ? `signal:${signal}` : code;
             if (exitCode !== 0) return settle(truncate(`Exit ${exitCode}: ${stderr || stdout || '(no output)'}`));
             if (!stdout && !stderr) return settle('(no output, exit 0)');

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -5,7 +5,7 @@ const cp     = require('child_process');
 const vscode = require('vscode');
 
 const { wsRoot } = require('../utils/paths');
-const { t }      = require('../utils/i18n');
+const { t, tf }      = require('../utils/i18n');
 const { truncate } = require('./utils');
 
 // ─── Dangerous-command detection ─────────────────────────────────────────────
@@ -98,12 +98,16 @@ async function toolRunShell(args, ctx = {}) {
         let killedByAbort   = false;
         let settled         = false;
         let lastOutputAt    = Date.now();                                   // for stall heartbeat — issue #69
+        // Declared up-front so settle() can safely reference it even if
+        // settle() is invoked before the interval is assigned. Stays null
+        // when onStreamDelta is absent (no consumer → no point waking up).
+        let stallTimer      = null;
 
         const settle = (val) => {
             if (settled) return;
             settled = true;
             clearTimeout(timer);
-            clearInterval(stallTimer);
+            if (stallTimer) clearInterval(stallTimer);
             if (abortSignal && onAbort) {
                 try { abortSignal.removeEventListener('abort', onAbort); } catch {}
             }
@@ -118,13 +122,17 @@ async function toolRunShell(args, ctx = {}) {
         // Stall heartbeat: when the process produces no output for STALL_PROBE_MS,
         // push a synthetic notice through onStreamDelta so the webview tail shows
         // "still alive but silent" and the user knows where things are stuck.
-        const stallTimer = setInterval(() => {
-            if (settled) return;
-            const silentMs = Date.now() - lastOutputAt;
-            if (silentMs >= STALL_PROBE_MS && onStreamDelta) {
-                try { onStreamDelta(`\n[Note: no output for last ${Math.round(silentMs / 1000)}s]\n`); } catch {}
-            }
-        }, STALL_PROBE_MS);
+        // Only create the interval when there is a stream consumer; otherwise
+        // we'd be waking the event loop with no observer.
+        if (onStreamDelta) {
+            stallTimer = setInterval(() => {
+                if (settled) return;
+                const silentMs = Date.now() - lastOutputAt;
+                if (silentMs >= STALL_PROBE_MS) {
+                    try { onStreamDelta('\n' + tf('shellNoOutput', { sec: Math.round(silentMs / 1000) }) + '\n'); } catch {}
+                }
+            }, STALL_PROBE_MS);
+        }
 
         const onAbort = () => {
             killedByAbort = true;
@@ -165,7 +173,7 @@ async function toolRunShell(args, ctx = {}) {
             if (killedByTimeout) {
                 const silentMs = Date.now() - lastOutputAt;
                 const stallNote = silentMs >= STALL_PROBE_MS
-                    ? `\n[Note: process was silent for last ${Math.round(silentMs / 1000)}s before timeout — likely hung (e.g. port in use, waiting for input, blocked on external resource). Do NOT retry blindly; report the situation to the user.]`
+                    ? '\n' + tf('shellSilentTimeout', { sec: Math.round(silentMs / 1000) })
                     : '';
                 return settle(truncate(`Error: command timed out after ${timeoutMs}ms${stallNote}\n${stdout}${stderr ? '\n--- stderr ---\n' + stderr : ''}`));
             }

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -90,6 +90,13 @@ const EN = {
     wvApprovalMode:     'Approval Mode',
     wvBalanceTitle:     'Account balance (click to refresh)',
     wvBalanceInit:      '💰 Checking...',
+
+    // run_shell stall/timeout diagnostics — issue #69
+    // The bracketed `[Note: ...]` prefix is a stable marker token the LLM is
+    // instructed (via tools/schema.js) to detect; keep it identical across
+    // locales and only localize the trailing human-readable explanation.
+    shellNoOutput:      '[Note: no output for last {sec}s]',
+    shellSilentTimeout: '[Note: process was silent for last {sec}s before timeout — likely hung (e.g. port in use, waiting for input, blocked on external resource). Do NOT retry blindly; report the situation to the user.]',
 };
 
 const ZH = {
@@ -170,6 +177,12 @@ const ZH = {
     wvApprovalMode:     '批准策略 (Approval Mode)',
     wvBalanceTitle:     '账户余额（点击刷新）',
     wvBalanceInit:      '💰 查询中…',
+
+    // run_shell stall/timeout diagnostics — issue #69
+    // 方括号内的 `[Note: ...]` 是给模型识别的稳定标记，跨语言保持一致；
+    // 仅本地化后面的中文说明部分。
+    shellNoOutput:      '[Note: no output for last {sec}s]（进程仍在运行，已 {sec} 秒未输出）',
+    shellSilentTimeout: '[Note: process was silent for last {sec}s before timeout — likely hung]（超时前 {sec} 秒静默，疑似挂起：端口被占用 / 等待输入 / 外部资源阻塞。不要盲目重试，请向用户报告。）',
 };
 
 function t(key) {
@@ -177,4 +190,16 @@ function t(key) {
     return bundle[key] != null ? bundle[key] : (EN[key] != null ? EN[key] : key);
 }
 
-module.exports = { t, isZh };
+// Formatted variant of t() — substitutes {placeholder} tokens with values
+// from params. Use for messages that need runtime values interpolated.
+function tf(key, params) {
+    let s = t(key);
+    if (params) {
+        for (const k of Object.keys(params)) {
+            s = s.split('{' + k + '}').join(String(params[k]));
+        }
+    }
+    return s;
+}
+
+module.exports = { t, tf, isZh };


### PR DESCRIPTION
## 问题

用户反馈：agent 执行某条命令后卡住（端口被占用、等待用户输入、等待外部资源），不会主动反馈，也不会停止任务，只是一直挂在那里。用户必须手动暂停后询问 agent 才说明情况。

复现场景：

- 启动服务器时端口已被占用，进程进入 WAIT 状态
- 模型传入了较大的 `timeout_ms`（如 `300000`），进程长时间无输出也无报错
- webview 仅显示静态「工具运行」提示，用户完全看不到卡在哪里

## 根因

| 问题 | 来源 |
|---|---|
| `timeout_ms` 无上限 | 模型可传入任意大超时，导致 `run_shell` 挂起数分钟 |
| 无输出时无任何反馈 | `onStreamDelta` 仅在有 stdout/stderr 时触发，挂起时 webview 毫无动静 |
| 超时错误不携带挂起信息 | 超时后错误消息不说明「是否有过输出」，模型无法判断「正常慢」 vs 「被阻塞」，倾向继续重试 |
| 工具描述未给挂起处置指引 | `run_shell` schema 描述未告知模型遇到挂起应停下 |

## 修复

### `src/tools/shell.js`

| 变更 | 作用 |
|---|---|
| `MAX_TIMEOUT_MS = 300_000`，`timeout_ms = Math.min(传入值, 300000)` | 防止模型传入超大超时值导致无限挂起 |
| 新增 `lastOutputAt` 与 `stallTimer`（每 15s 检查一次） | 进程 ≥15s 无输出时，通过 `onStreamDelta` 向 webview 实时尾流推 `[Note: no output for last Ns]` 心跳，用户立刻看到卡住提示 |
| 超时错误消息附加挂起说明 | 超时时若沉默时间 ≥15s，错误字符串追加挂起说明，模型读到后知道应停止并告知用户 |

### `src/tools/schema.js`

更新 `run_shell` 工具描述：若结果含 `[Note: no output for last …s]` 或 `[Note: process was silent for last …s before timeout]`，表示进程已挂起（端口被占、等待输入等）—— 应立即停止，如实告知用户，而不是重试。同时标注 timeout 上限为 300000ms。

## 行为对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 进程挂起时 webview 提示 | 仅静态「工具运行」 | 每 15s 追加实时心跳 |
| 超时错误消息 | 仅 `Error: command timed out after Xms` | 附带无输出挂起说明 |
| 模型行为 | 继续重试或无限等待 | 读到挂起说明后停下来告知用户 |
| `timeout_ms` 上限 | 无限制 | 最大 300,000ms（5 分钟） |

## 影响范围

- `src/tools/shell.js` + `src/tools/schema.js`，27 行新增 / 4 行删除
- 仅影响 `run_shell` 工具调用路径，对其他工具透明
- 心跳通过既有 `onStreamDelta` 通道推送，无新协议字段

Closes #69
