### PR TITLE
ci: trigger Copilot review on PR synchronize (full-auto re-review)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -2,7 +2,7 @@ name: Request Copilot Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Add 'synchronize' to the pull_request trigger so every new commit pushed to a PR branch automatically re-requests Copilot review.

Part of the full-automation pipeline restoration (see also: ruleset cleanup, actions/permissions=all, default_workflow_permissions=write applied via API).