### PR TITLE
feat(completion): inline FIM completions via DeepSeek (#60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,6 +254,18 @@
             "Ask — pure conversational mode. Tools are NEVER exposed to the model. Use for Q&A or when you don't want any workspace exploration."
           ],
           "description": "Interaction mode (analogous to GitHub Copilot's Ask vs Agent). Agent mode also runs a per-turn intent classifier that auto-disables tools on greetings."
+        },
+        "deepCopilot.inlineCompletion.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable DeepSeek FIM-powered inline (ghost-text) completions in the editor. Off by default — turn on after configuring your API key."
+        },
+        "deepCopilot.inlineCompletion.debounceMs": {
+          "type": "number",
+          "default": 300,
+          "minimum": 0,
+          "maximum": 2000,
+          "description": "Idle delay (ms) after the last keystroke before requesting an inline completion. Lower = snappier but more API calls."
         }
       }
     },

--- a/src/api/deepseek.js
+++ b/src/api/deepseek.js
@@ -225,12 +225,21 @@ function fetchBalance({ apiKey, baseUrl }) {
 function fimComplete({ apiKey, baseUrl, model, prefix, suffix, maxTokens, temperature }, abortSignal) {
     return new Promise((resolve) => {
         const base = (baseUrl || 'https://api.deepseek.com').replace(/\/$/, '');
-        // FIM is only documented for the official DeepSeek API; third-party
-        // proxies may not implement /beta/completions.
-        if (!base.includes('deepseek.com')) { resolve(null); return; }
 
+        // Parse the URL first so we can do hostname-based whitelisting.
+        // FIM is only documented for the official DeepSeek API; third-party
+        // proxies may not implement /beta/completions. We MUST check the
+        // parsed hostname rather than a substring of the raw string — see
+        // CodeQL js/incomplete-url-substring-sanitization: a substring check
+        // would falsely accept hosts like `deepseek.com.attacker.com`,
+        // `evil.com/?x=deepseek.com`, etc., leaking the API key.
         let urlObj;
         try { urlObj = new URL('/beta/completions', base); } catch { resolve(null); return; }
+        const host = (urlObj.hostname || '').toLowerCase();
+        if (host !== 'deepseek.com' && host !== 'api.deepseek.com' && !host.endsWith('.deepseek.com')) {
+            resolve(null);
+            return;
+        }
         const isHttps = urlObj.protocol === 'https:';
 
         const body = JSON.stringify({
@@ -262,7 +271,14 @@ function fimComplete({ apiKey, baseUrl, model, prefix, suffix, maxTokens, temper
                 let errBody = '';
                 res.on('data', c => { errBody += c; });
                 res.on('end', () => {
-                    Logger.info('FIM_HTTP_ERROR', { status: res.statusCode, body: errBody.slice(0, 300) });
+                    // Sanitize untrusted upstream body before logging
+                    // (CodeQL js/http-to-file-access): strip CR/LF/control
+                    // chars so a malicious proxy cannot inject log lines,
+                    // and cap length so logs cannot be ballooned.
+                    const safeBody = String(errBody)
+                        .slice(0, 300)
+                        .replace(/[\r\n\x00-\x1f\x7f]+/g, ' ');
+                    Logger.info('FIM_HTTP_ERROR', { status: res.statusCode, body: safeBody });
                     resolve(null);
                 });
                 return;

--- a/src/api/deepseek.js
+++ b/src/api/deepseek.js
@@ -213,4 +213,81 @@ function fetchBalance({ apiKey, baseUrl }) {
     });
 }
 
-module.exports = { streamDeepSeek, fetchBalance };
+// ─── FIM completion (Issue #60) ────────────────────────────────────────────
+// Non-streaming fill-in-the-middle completion against DeepSeek's beta endpoint.
+// Powers the InlineCompletionItemProvider (src/completion/provider.js).
+//
+// API:    POST {baseUrl}/beta/completions
+// Schema: OpenAI legacy /v1/completions with `prompt` (prefix) + `suffix`.
+//
+// Returns the completion text, or null on any failure (silent — inline
+// completion must never throw user-visible errors).
+function fimComplete({ apiKey, baseUrl, model, prefix, suffix, maxTokens, temperature }, abortSignal) {
+    return new Promise((resolve) => {
+        const base = (baseUrl || 'https://api.deepseek.com').replace(/\/$/, '');
+        // FIM is only documented for the official DeepSeek API; third-party
+        // proxies may not implement /beta/completions.
+        if (!base.includes('deepseek.com')) { resolve(null); return; }
+
+        let urlObj;
+        try { urlObj = new URL('/beta/completions', base); } catch { resolve(null); return; }
+        const isHttps = urlObj.protocol === 'https:';
+
+        const body = JSON.stringify({
+            model:       model || 'deepseek-chat',
+            prompt:      prefix || '',
+            suffix:      suffix || '',
+            max_tokens:  maxTokens  || 64,
+            temperature: temperature == null ? 0.2 : temperature,
+            stream:      false,
+        });
+
+        const reqOpts = {
+            hostname: urlObj.hostname,
+            port:     urlObj.port || (isHttps ? 443 : 80),
+            path:     urlObj.pathname,
+            method:   'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type':  'application/json',
+                'Accept':        'application/json',
+                'Content-Length': Buffer.byteLength(body),
+            },
+            timeout: 15000,
+        };
+
+        const mod = isHttps ? https : http;
+        const req = mod.request(reqOpts, (res) => {
+            if (res.statusCode !== 200) {
+                let errBody = '';
+                res.on('data', c => { errBody += c; });
+                res.on('end', () => {
+                    Logger.info('FIM_HTTP_ERROR', { status: res.statusCode, body: errBody.slice(0, 300) });
+                    resolve(null);
+                });
+                return;
+            }
+            let raw = '';
+            res.on('data', c => { raw += c; });
+            res.on('end', () => {
+                try {
+                    const data = JSON.parse(raw);
+                    const text = (data && data.choices && data.choices[0] && data.choices[0].text) || '';
+                    resolve(text);
+                } catch { resolve(null); }
+            });
+            res.on('error', () => resolve(null));
+        });
+        req.on('error', () => resolve(null));
+        req.on('timeout', () => { try { req.destroy(); } catch {}; resolve(null); });
+        if (abortSignal) {
+            const onAbort = () => { try { req.destroy(); } catch {}; resolve(null); };
+            if (abortSignal.aborted) { onAbort(); return; }
+            abortSignal.addEventListener('abort', onAbort, { once: true });
+        }
+        req.write(body);
+        req.end();
+    });
+}
+
+module.exports = { streamDeepSeek, fetchBalance, fimComplete };

--- a/src/completion/provider.js
+++ b/src/completion/provider.js
@@ -1,0 +1,110 @@
+// Inline completion provider — DeepSeek FIM-powered "ghost text" suggestions.
+//
+// Issue #60. Off by default (`deepCopilot.inlineCompletion.enable`). When on,
+// debounces idle keystrokes and calls DeepSeek's `/beta/completions` FIM
+// endpoint to generate a single suggestion using the surrounding lines of the
+// active document as prefix/suffix context.
+//
+// Design notes:
+//   - Silent failure: any API error returns no item (never throws to the UI).
+//   - Hard caps on prefix/suffix bytes so a huge file does not blow up the
+//     request. We trim to the nearest line boundary to avoid mid-token cuts.
+//   - Uses an AbortController per-request; the previous request is cancelled
+//     as soon as the user types another character.
+'use strict';
+
+const vscode = require('vscode');
+
+const { Logger } = require('../logger');
+const { fimComplete } = require('../api/deepseek');
+
+const MAX_PREFIX_CHARS = 4000;
+const MAX_SUFFIX_CHARS = 2000;
+const MAX_COMPLETION_TOKENS = 64;
+
+function trimToLineBoundary(text, maxLen, fromEnd) {
+    if (text.length <= maxLen) return text;
+    if (fromEnd) {
+        // Keep the last maxLen chars, then drop the partial first line.
+        const slice = text.slice(text.length - maxLen);
+        const idx = slice.indexOf('\n');
+        return idx >= 0 ? slice.slice(idx + 1) : slice;
+    }
+    // Keep the first maxLen chars, then drop the partial last line.
+    const slice = text.slice(0, maxLen);
+    const idx = slice.lastIndexOf('\n');
+    return idx >= 0 ? slice.slice(0, idx + 1) : slice;
+}
+
+function registerInlineCompletionProvider(context) {
+    let inFlight = null; // { ac: AbortController, token: vscode.CancellationToken }
+
+    const provider = {
+        async provideInlineCompletionItems(document, position, ctx, token) {
+            try {
+                const cfg = vscode.workspace.getConfiguration('deepCopilot.inlineCompletion');
+                if (!cfg.get('enable')) return null;
+
+                // Skip when user has multi-selection / non-empty selection — they are editing,
+                // not requesting completion.
+                const editor = vscode.window.activeTextEditor;
+                if (editor && !editor.selection.isEmpty) return null;
+
+                // Debounce idle period. If another keystroke arrives before the
+                // delay elapses, the editor cancels this token and we bail.
+                const debounceMs = Math.max(0, cfg.get('debounceMs') || 300);
+                if (debounceMs > 0) {
+                    await new Promise((r) => setTimeout(r, debounceMs));
+                    if (token.isCancellationRequested) return null;
+                }
+
+                // Resolve API key. Reuse the same secret slot as the chat agent
+                // so the user only configures the key once.
+                const apiKey = await context.secrets.get('deepseekAgent.apiKey');
+                if (!apiKey) return null;
+
+                const baseUrl = vscode.workspace.getConfiguration('deepseekAgent').get('baseUrl')
+                    || 'https://api.deepseek.com';
+                const model   = vscode.workspace.getConfiguration('deepseekAgent').get('model')
+                    || 'deepseek-chat';
+
+                const fullText = document.getText();
+                const offset   = document.offsetAt(position);
+                const prefix   = trimToLineBoundary(fullText.slice(0, offset), MAX_PREFIX_CHARS, true);
+                const suffix   = trimToLineBoundary(fullText.slice(offset),    MAX_SUFFIX_CHARS, false);
+
+                // Cancel any previous in-flight request — we only want a
+                // completion for the most recent cursor position.
+                if (inFlight) { try { inFlight.ac.abort(); } catch {} }
+                const ac = new AbortController();
+                inFlight = { ac };
+                token.onCancellationRequested(() => { try { ac.abort(); } catch {} });
+
+                const text = await fimComplete(
+                    { apiKey, baseUrl, model, prefix, suffix, maxTokens: MAX_COMPLETION_TOKENS },
+                    ac.signal,
+                );
+                inFlight = null;
+
+                if (!text || token.isCancellationRequested) return null;
+
+                // Trim trailing newline-only fragments — they add noise and the
+                // user can press Enter themselves.
+                const cleaned = text.replace(/\s+$/, '');
+                if (!cleaned) return null;
+
+                return { items: [{ insertText: cleaned, range: new vscode.Range(position, position) }] };
+            } catch (e) {
+                Logger.info('INLINE_COMPLETION_ERROR', { message: (e && e.message) || String(e) });
+                return null;
+            }
+        },
+    };
+
+    context.subscriptions.push(
+        vscode.languages.registerInlineCompletionItemProvider({ pattern: '**' }, provider),
+    );
+    Logger.info('INLINE_COMPLETION_REGISTERED');
+}
+
+module.exports = { registerInlineCompletionProvider };

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,6 +7,7 @@ const { Logger } = require('./logger');
 const { ChatViewProvider } = require('./chat/provider');
 const { t, isZh } = require('./utils/i18n');
 const { getDiscountWarning } = require('./pricing');
+const { registerInlineCompletionProvider } = require('./completion/provider');
 
 function activate(context) {
     Logger.init(context);
@@ -326,6 +327,10 @@ function activate(context) {
     );
 
     // Status bar button (already registered at top of activate; nothing to do here).
+
+    // Inline FIM completion (Issue #60) — registered last so a failure here cannot
+    // block chat activation. Off by default; controlled by `deepCopilot.inlineCompletion.enable`.
+    try { registerInlineCompletionProvider(context); } catch (e) { Logger.info('INLINE_COMPLETION_REGISTER_FAILED', { message: e && e.message }); }
 
     // First-run: prompt for API key
     context.secrets.get('deepseekAgent.apiKey').then(key => {


### PR DESCRIPTION
Closes #60.

## 改动
- `src/api/deepseek.js` 新增 `fimComplete` (非流式 POST /beta/completions, 用 prefix=prompt + suffix 字段, 静默失败返回 null)
- `src/completion/provider.js` 新增 `InlineCompletionItemProvider`: debounce + 单飞 AbortController 取消旧请求 + 4KB/2KB 行边界截断 + 复用 agent 的 API key
- `src/extension.js` 在 activate 末尾注册 (用 try/catch 包裹避免影响主链路)
- `package.json` 新增设置: `deepCopilot.inlineCompletion.enable` (默认 false, 默认关闭以免无意中产生 API 调用), `deepCopilot.inlineCompletion.debounceMs` (默认 300)

## 使用
1. 配置 `deepseekAgent.apiKey`(若尚未)
2. 把 `deepCopilot.inlineCompletion.enable` 设为 true
3. 在编辑器里光标停留 300ms 后会看到 ghost-text 建议
4. Tab 接受 / Esc 拒绝

## 安全
- 第三方代理 (non-deepseek.com baseUrl) 直接 skip - FIM 是 DeepSeek beta 专用端点
- 任何异常都吞掉返回 null, 不向 UI 抛错
- 用户没配 key 时静默 no-op