### PR TITLE
feat(plan): add Plan interaction mode (read-only investigation) (#66)

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
             "Ask — pure conversational mode. Tools are NEVER exposed to the model. Use for Q&A or when you don't want any workspace exploration."
           ],
           "description": "Interaction mode (analogous to GitHub Copilot's Ask / Plan / Agent). Agent mode also runs a per-turn intent classifier that auto-disables tools on greetings."
-        },
+        }
       }
     },
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -247,14 +247,16 @@
           "default": "agent",
           "enum": [
             "agent",
+            "plan",
             "ask"
           ],
           "enumDescriptions": [
             "Agent — model can autonomously call tools (file reads, edits, shell, etc.). Recommended for coding tasks.",
+            "Plan — model can only use read-only tools to explore and produce a plan. All write/shell tools are blocked. Switch to Agent mode to execute the plan.",
             "Ask — pure conversational mode. Tools are NEVER exposed to the model. Use for Q&A or when you don't want any workspace exploration."
           ],
-          "description": "Interaction mode (analogous to GitHub Copilot's Ask vs Agent). Agent mode also runs a per-turn intent classifier that auto-disables tools on greetings."
-        }
+          "description": "Interaction mode (analogous to GitHub Copilot's Ask / Plan / Agent). Agent mode also runs a per-turn intent classifier that auto-disables tools on greetings."
+        },
       }
     },
     "keybindings": [

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -191,14 +191,15 @@ class AgentLoop {
             });
         };
 
-        const sysPrompt = buildSystemPrompt({ includeWorkspaceInstructions: true });
+        const interactionMode = cfg.get('interactionMode') || 'agent';
+        const sysPrompt = buildSystemPrompt({ includeWorkspaceInstructions: true, mode: interactionMode });
         const _itersRaw = Number(cfg.get('maxIterations'));
         // 0 (or unset) means "run until task is complete" — stagnation detection
         // (repeat-tool hints + ABAB cycle guard) is the real runaway guard.
         const MAX_ITERS = (_itersRaw > 0) ? Math.min(200, _itersRaw) : 9999;
         const COMPACT_BUDGET = Math.max(8000, Number(cfg.get('compactBudgetTokens')) || 600000);
-        const askMode = (cfg.get('interactionMode') || 'agent') === 'ask';
-        Logger.info('INTERACTION_MODE', { mode: cfg.get('interactionMode') || 'agent' });
+        const askMode = interactionMode === 'ask';
+        Logger.info('INTERACTION_MODE', { mode: interactionMode });
 
         // spawn_agent is included here so multiple sub-agent calls issued in the
         // same turn are dispatched concurrently (Phase 1), matching the behaviour of

--- a/src/chat/tool-executor.js
+++ b/src/chat/tool-executor.js
@@ -281,6 +281,14 @@ class ToolExecutor {
         const isMutating = ToolExecutor.MUTATING.has(name);
         if (approvalMode === 'readonly' && isMutating) return t('deniedReadonly');
 
+        // Issue #66: Plan mode is a soft "readonly" enforced at the executor.
+        // The system prompt also instructs the model to stay read-only, but
+        // we still guard the executor in case the model ignores the prompt.
+        const interactionMode = cfg.get('interactionMode') || 'agent';
+        if (interactionMode === 'plan' && isMutating) {
+            return `PLAN_MODE_FORBIDDEN: ${name} is a write/exec tool and is disabled in Plan mode. Stay read-only (read_file, grep_search, list_dir, find_files, web_search, web_fetch, update_plan) and produce a plan for the user to review. The user can switch to Agent mode to execute it.`;
+        }
+
         const skipApproval = autoApprove.includes(name);
 
         // Approval dialogs for write + shell

--- a/src/prompts/system.js
+++ b/src/prompts/system.js
@@ -320,6 +320,22 @@ function buildSystemPrompt(opts = {}) {
         if (ws) dynamicParts.push(ws);
     }
 
+    // Issue #66: Plan mode — instruct the model to stay read-only and produce a
+    // plan for the user to approve. The executor (tool-executor.js) also blocks
+    // mutating tools as a safety net.
+    if (opts.mode === 'plan') {
+        dynamicParts.push(
+            '# Plan mode (do NOT edit, do NOT execute)\n' +
+            'You are in Plan mode. You MAY use read-only tools (read_file, grep_search, list_dir, find_files, web_search, web_fetch) to investigate the task. ' +
+            'You MUST NOT use write_file, str_replace_in_file, apply_patch, run_shell, or skill_create — these are blocked at the executor level and will return PLAN_MODE_FORBIDDEN.\n\n' +
+            'Your single goal this turn is to produce a clear, actionable plan for the user to review:\n' +
+            '1. Call `update_plan` early with the high-level steps so the user can follow along.\n' +
+            '2. Investigate (read code, grep, list dirs) only as much as is needed to write a correct plan.\n' +
+            '3. End with a final assistant message that summarises: the goal, the proposed approach, the affected files, the risks, and explicit next steps.\n' +
+            "Do NOT start implementing. The user will switch to Agent mode to execute the plan if they approve it."
+        );
+    }
+
     return `${staticPart}\n\n${DYNAMIC_BOUNDARY}\n\n${dynamicParts.join('\n\n')}`;
 }
 


### PR DESCRIPTION
Closes #66 (backend MVP).

## 改动
第三种交互模式 `plan` 与 `agent` / `ask` 并列。

- `package.json`: 扩展 `deepseekAgent.interactionMode` enum, 加 plan 选项 + 描述
- `src/prompts/system.js`: `buildSystemPrompt` 新增 `{ mode }` 参数; mode='plan' 时附加 Plan 段落, 指示模型保持只读, 用 update_plan 列步骤, 最后产出供用户审阅的计划
- `src/chat/agent-loop.js`: 读 interactionMode 一次, 转发给 buildSystemPrompt
- `src/chat/tool-executor.js`: execute 入口加 plan-gate, 任何 mutating 工具 (write_file / str_replace_in_file / apply_patch / run_shell / skill_create) 返回 `PLAN_MODE_FORBIDDEN` 错误, 即使模型忽略 system prompt 也拦得住

## 使用
1. Settings → Deep Copilot → Interaction Mode 选 plan
2. 提需求, 模型只读探索 + 产出计划
3. 审阅, 切回 agent 模式让它执行

## 后续 (单独 PR)
UI segmented control (Agent/Plan/Ask 输入框旁), 计划面板底部 'Handoff to Agent' 按钮, 状态栏三联指示——为聚焦 PR 范围本次不一并提交。