### PR TITLE
fix(shell): skip danger-cmd modal in autopilot + add per-session approval cache (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ All settings live under the `deepseekAgent.*` namespace in `settings.json`.
 | **autopilot** | Auto-approve everything (trusted workspaces only)             | 全部自动通过（仅适合受信任工作区） |
 | **readonly**  | Deny all writes & shell                                       | 仅允许只读，禁止任何修改           |
 
+> Issue #89 · Autopilot 与危险命令：`autopilot` 模式下，命中危险命令正则（`rm -rf`、`git reset --hard`、`git push --force` …）的 shell 调用会**静默放行**，并写入 `SHELL_DANGER_AUTO_APPROVE` 审计日志，不再弹模态确认框；其他模式中，同一条命令在一次会话内被批准过一次后也会缓存，不会重复弹框。若把 `run_shell` 加入 `autoApproveTools`，效果等同于显式承担 shell 风险，请仅在受信任工作区开启。
+
 ---
 
 ## ⌨️ Keybindings · 快捷键

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -7,6 +7,14 @@ const vscode = require('vscode');
 const { wsRoot } = require('../utils/paths');
 const { t, tf }      = require('../utils/i18n');
 const { truncate } = require('./utils');
+const { Logger }   = require('../logger');
+
+// Issue #89: Cache normalized danger-command approvals for the current
+// extension session. Once the user grants "Allow once" (or `auto-edit`
+// implicitly approves via this cache), the same command will not re-prompt
+// inside the same session. Survives reloads but not a full VS Code restart.
+const _dangerCmdApprovals = new Set();
+function _normCmd(cmd) { return String(cmd || '').replace(/\s+/g, ' ').trim(); }
 
 // ─── Dangerous-command detection ─────────────────────────────────────────────
 
@@ -68,8 +76,28 @@ async function confirmDangerous(cmd, abortSignal) {
 async function toolRunShell(args, ctx = {}) {
     const command = args.command || '';
     if (isDangerous(command)) {
-        const allowed = await confirmDangerous(command, ctx.abortSignal);
-        if (!allowed) return `${t('dangerBlocked')}\n\nCommand: ${command}`;
+        // Issue #89: align dangerous-command gate with `approvalMode` /
+        // `autoApproveTools`, matching `ensurePathAllowed()` semantics.
+        // - autopilot           → silently allow + audit log (user granted blanket approval by choosing the mode)
+        // - autoApproveTools ⊇ run_shell → silently allow (explicit opt-in)
+        // - session cache hit   → silently allow (don't re-prompt for the same command in the same session)
+        // - otherwise           → modal confirm (existing manual / auto-edit behavior)
+        const cfg = vscode.workspace.getConfiguration('deepseekAgent');
+        const approvalMode    = cfg.get('approvalMode') || 'manual';
+        const autoApproveTools = cfg.get('autoApproveTools') || [];
+        const cacheKey = _normCmd(command);
+
+        if (approvalMode === 'autopilot') {
+            try { Logger.info('SHELL_DANGER_AUTO_APPROVE', { reason: 'autopilot', command }); } catch {}
+            _dangerCmdApprovals.add(cacheKey);
+        } else if (Array.isArray(autoApproveTools) && autoApproveTools.includes('run_shell')) {
+            try { Logger.info('SHELL_DANGER_AUTO_APPROVE', { reason: 'autoApproveTools', command }); } catch {}
+            _dangerCmdApprovals.add(cacheKey);
+        } else if (!_dangerCmdApprovals.has(cacheKey)) {
+            const allowed = await confirmDangerous(command, ctx.abortSignal);
+            if (!allowed) return `${t('dangerBlocked')}\n\nCommand: ${command}`;
+            _dangerCmdApprovals.add(cacheKey);
+        }
     }
 
     const MAX_BUF       = 10 * 1024 * 1024;
@@ -203,4 +231,4 @@ async function toolRunShell(args, ctx = {}) {
     });
 }
 
-module.exports = { toolRunShell, isDangerous };
+module.exports = { toolRunShell, isDangerous, _dangerCmdApprovals };


### PR DESCRIPTION
Closes #89.

## Problem

Under pprovalMode === 'autopilot', 	oolRunShell still raised a modal scode.window.showWarningMessage({ modal: true }, ...) for every command that matched isDangerous() (e.g. m -rf, git reset --hard, git push --force). That is inconsistent with:

- The documented Autopilot semantics (the user has granted blanket approval by choosing the mode).
- The v0.32.9 fix to ensurePathAllowed() in src/tools/utils.js, which already silently allows out-of-workspace access under autopilot.

In retry / loop scenarios (the reporter's case is an ORB_SLAM3 dataset run wrapped in m -rf … && mkdir -p … && stereo_inertial_dataset …) the modal pops on every iteration even after the user has already approved.

## Fix

src/tools/shell.js only — isDangerous() regex set is untouched.

- pprovalMode === 'autopilot' → silently allow + audit log Logger.info('SHELL_DANGER_AUTO_APPROVE', { reason: 'autopilot', command }).
- utoApproveTools includes 'run_shell' → silently allow + same audit log (explicit per-tool opt-in already advertised in the schema).
- Otherwise → existing manual / auto-edit modal, **plus** a session-level _dangerCmdApprovals: Set<string> cache keyed by the whitespace-normalised command, so the same command in the same session doesn't re-prompt.

## Docs

README.md Approval Modes table now calls out the new Autopilot behaviour and audit log (\SHELL_DANGER_AUTO_APPROVE\ in .deep-copilot/logs/).

## Out of scope

- isDangerous() regex set (kept verbatim — still gates manual / auto-edit).
- Webview UI changes.