### PR TITLE
feat(context-chip): 自动感知当前文件，支持多根工作区与外部文件 (#97)

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -280,6 +280,11 @@ body.narrow #ia{padding-left:8px;padding-right:8px}
 .chip-name{flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .chip-line{opacity:.7;font-size:10.5px;flex-shrink:0}
 .chip-live{background:var(--vscode-editor-selectionBackground,rgba(0,120,215,.18));border-color:var(--vscode-editor-selectionHighlightBorder,rgba(0,120,215,.4))}
+/* Issue #97: external files are shown but visually de-emphasized — they are
+   visible to the user but not auto-attached to the prompt. A dashed border
+   distinguishes them from in-workspace chips at a glance. */
+.chip-external{opacity:.65;border-style:dashed;background:transparent}
+.chip-external .chip-ico{color:var(--vscode-descriptionForeground,inherit)}
 #inp-row{display:flex;align-items:flex-start;width:100%}
 #skill-notice{display:none;align-items:center;gap:5px;background:#0074cc;color:#fff;border-radius:12px;padding:3px 8px 3px 11px;font-size:12px;font-weight:500;white-space:nowrap;flex-shrink:0;margin:8px 0 0 10px;align-self:flex-start}
 #skill-notice .skill-notice-x{background:none;border:none;color:#fff;cursor:pointer;font-size:15px;line-height:1;padding:0;opacity:.75}

--- a/media/chat.js
+++ b/media/chat.js
@@ -1201,7 +1201,14 @@
       var lsLine = (liveSelection.startLine !== undefined && liveSelection.endLine !== undefined)
         ? '<span class="chip-line">:' + liveSelection.startLine + (liveSelection.endLine !== liveSelection.startLine ? '-' + liveSelection.endLine : '') + '</span>'
         : '';
-      liveHtml = '<span class="chip chip-live" title="'+escHtml(liveSelection.path)+'">' +
+      // Issue #97: external files (outside any workspace folder) are shown
+      // with a dimmer style and a tooltip that exposes the absolute path,
+      // signalling that they are visible but NOT auto-included in the prompt.
+      var extCls = liveSelection.external ? ' chip-external' : '';
+      var extTip = liveSelection.external
+        ? ('External (\u5916\u90e8\u6587\u4ef6, \u4e0d\u81ea\u52a8\u9644\u5e26): ' + liveSelection.path)
+        : liveSelection.path;
+      liveHtml = '<span class="chip chip-live'+extCls+'" title="'+escHtml(extTip)+'">' +
         '<span class="codicon codicon-selection chip-ico"></span>' +
         '<span class="chip-name">' + escHtml(lsName) + '</span>' + lsLine +
         '<button class="chip-x chip-x-live" title="取消选区">×</button></span>';
@@ -1592,7 +1599,10 @@
     // selected content. Bare "file-open" chips are visual markers only; the
     // active editor's context is provided by the backend via the standard
     // attachment-block path so we avoid sending an "(empty)" placeholder.
-    if (liveSelection && liveSelection.content) _allAtt.push(liveSelection);
+    // Issue #97: external files (outside any workspace folder) are visible
+    // via the chip but must NOT auto-leak into the prompt. The user must
+    // explicitly attach them via right-click / #file picker if desired.
+    if (liveSelection && liveSelection.content && !liveSelection.external) _allAtt.push(liveSelection);
     _allAtt = _allAtt.concat(attachedFiles.filter(function(f){ return f.content !== null || !!f.imageData; }));
     if (_allAtt.length) { toSend.attachments = _allAtt; }
     if (_pendingRefs && _pendingRefs.length) { toSend.pendingRefs = _pendingRefs; }

--- a/src/chat/provider.js
+++ b/src/chat/provider.js
@@ -16,7 +16,7 @@ const path   = require('path');
 const fs     = require('fs');
 
 const { Logger }           = require('../logger');
-const { wsRoot, resolvePath, isInsideWorkspace } = require('../utils/paths');
+const { wsRoot, resolvePath, isInsideWorkspace, findContainingFolder } = require('../utils/paths');
 const { isZh }             = require('../utils/i18n');
 const { openFile }         = require('./openFile');
 const { buildWebviewHtml } = require('../webview/html');
@@ -158,6 +158,10 @@ class ChatViewProvider {
                     const skills = discoverSkills().map(s => ({ name: s.name, desc: s.desc, hint: s.hint }));
                     if (skills.length) this._post({ type: 'skillList', skills });
                 } catch { /* non-fatal: skill discovery failures must not break startup */ }
+                // Issue #97: push the current active editor as the initial chip
+                // so users see context immediately after the webview boots,
+                // without having to click into the editor first.
+                try { this.attachLiveSelection(vscode.window.activeTextEditor); } catch { /* non-fatal */ }
                 break;
             }
             case 'balanceRefresh': this._refreshBalance(true); break;
@@ -560,6 +564,35 @@ class ChatViewProvider {
     // ─── Public API for extension commands ──────────────────────────────────
 
     /**
+     * Compute display path + workspace location for a TextDocument.
+     * Issue #97: multi-root aware + external-file aware.
+     *  - Returns null for unsupported schemes (we only handle file/untitled;
+     *    synthetic schemes like git:/output:/vscode-userdata: are intentionally
+     *    refused because their contents are derived views, not source files).
+     *  - For workspace-internal files, `rel` is relative to the *containing*
+     *    folder (not necessarily the first one).
+     *  - For workspace-external files, `external` is true and `rel` falls back
+     *    to the absolute path so the UI can disambiguate same-named files.
+     *
+     * @param {import('vscode').TextDocument} doc
+     * @returns {{ abs: string, rel: string, external: boolean, untitled: boolean } | null}
+     */
+    _resolveDocLocation(doc) {
+        if (!doc) return null;
+        const scheme = doc.uri.scheme;
+        if (scheme !== 'file' && scheme !== 'untitled') return null;
+        if (scheme === 'untitled') {
+            return { abs: doc.uri.toString(), rel: doc.fileName || 'Untitled', external: false, untitled: true };
+        }
+        const abs = doc.fileName;
+        const hit = findContainingFolder(abs);
+        if (hit) return { abs, rel: hit.rel, external: false, untitled: false };
+        // External: not inside any workspace folder. Use absolute path as the
+        // display key; the UI marks it with a distinct style.
+        return { abs, rel: abs.replace(/\\/g, '/'), external: true, untitled: false };
+    }
+
+    /**
      * Read the active editor selection (or entire file if nothing selected)
      * and push an addAttachment message to the webview.
      * Called by the deepseekAgent.attachSelection command.
@@ -573,21 +606,9 @@ class ChatViewProvider {
             return;
         }
         const doc = editor.document;
-        if (doc.uri.scheme !== 'file' && doc.uri.scheme !== 'untitled') return;
+        const loc = this._resolveDocLocation(doc);
+        if (!loc) return;
 
-        const abs  = doc.fileName;
-        const root = wsRoot();
-        // Security: reject paths outside the workspace
-        if (doc.uri.scheme === 'file' && root && !isInsideWorkspace(abs)) {
-            vscode.window.showWarningMessage(
-                isZh() ? 'Deep Copilot: 只能附加工作区内的文件' : 'Deep Copilot: Only files inside the workspace can be attached'
-            );
-            return;
-        }
-
-        const rel  = root && abs.startsWith(root)
-            ? path.relative(root, abs).replace(/\\/g, '/')
-            : path.basename(abs);
         const lang = doc.languageId;
         const sel  = editor.selection;
 
@@ -602,7 +623,13 @@ class ChatViewProvider {
             if (content.length > 65536) content = content.slice(0, 65536) + '\n... [截断]';
         }
 
-        this._post({ type: 'addAttachment', payload: { path: rel, content, startLine, endLine, lang } });
+        // Issue #97: for explicit user-driven attach (right-click / command),
+        // we honor the user's intent even on external files — they asked for
+        // it. We still tag `external` so the UI can flag it.
+        this._post({
+            type: 'addAttachment',
+            payload: { path: loc.rel, content, startLine, endLine, lang, external: loc.external },
+        });
         // Focus the chat panel so the user can see the chip was added
         vscode.commands.executeCommand('deepseek.chatView.focus').then(() => {}, () => {});
     }
@@ -612,19 +639,23 @@ class ChatViewProvider {
      * by the active-editor-change listener. Always shows a chip for the
      * currently active file. If a non-empty selection exists, the chip also
      * carries the selected text + line range; otherwise it's just a name tag.
+     *
+     * Issue #97:
+     *  - Multi-root aware: paths are computed relative to the *containing*
+     *    workspace folder, not just folders[0].
+     *  - External files (outside every workspace folder) are no longer
+     *    silently dropped. The chip is rendered with an `external` flag so
+     *    the user can see what they have open; the prompt-side attachment
+     *    block below skips them so they don't auto-leak into requests.
      * @param {import('vscode').TextEditor} [editor]
      */
     attachLiveSelection(editor) {
         if (!editor) editor = vscode.window.activeTextEditor;
         if (!editor) { this.clearLiveSelection(); return; }
         const doc = editor.document;
-        if (doc.uri.scheme !== 'file' && doc.uri.scheme !== 'untitled') { this.clearLiveSelection(); return; }
-        const abs  = doc.fileName;
-        const root = wsRoot();
-        if (doc.uri.scheme === 'file' && root && !isInsideWorkspace(abs)) { this.clearLiveSelection(); return; }
-        const rel  = root && abs.startsWith(root)
-            ? path.relative(root, abs).replace(/\\/g, '/')
-            : path.basename(abs);
+        const loc = this._resolveDocLocation(doc);
+        if (!loc) { this.clearLiveSelection(); return; }
+
         const lang = doc.languageId;
         const sel  = editor.selection;
         if (sel && !sel.isEmpty) {
@@ -632,7 +663,10 @@ class ChatViewProvider {
             const startLine = sel.start.line + 1;
             const endLine   = sel.end.line + 1;
             if (content.length > 12000) content = content.slice(0, 12000) + (isZh() ? '\n... [截断]' : '\n... [truncated]');
-            this._post({ type: 'setLiveSelection', payload: { path: rel, content, startLine, endLine, lang } });
+            this._post({
+                type: 'setLiveSelection',
+                payload: { path: loc.rel, content, startLine, endLine, lang, external: loc.external },
+            });
         } else {
             // File is open but no selection: include the full document content
             // (truncated) so that sending the chip attaches the whole file.
@@ -640,7 +674,10 @@ class ChatViewProvider {
             let content = doc.getText();
             const truncated = content.length > FILE_CAP;
             if (truncated) content = content.slice(0, FILE_CAP) + (isZh() ? '\n... [文件超出 60KB 已截断]' : '\n... [file exceeded 60KB and was truncated]');
-            this._post({ type: 'setLiveSelection', payload: { path: rel, content, lang } });
+            this._post({
+                type: 'setLiveSelection',
+                payload: { path: loc.rel, content, lang, external: loc.external },
+            });
         }
     }
 
@@ -653,14 +690,16 @@ class ChatViewProvider {
         const editor = vscode.window.activeTextEditor;
         if (!editor) return null;
         const doc  = editor.document;
-        if (doc.uri.scheme !== 'file' && doc.uri.scheme !== 'untitled') return null;
+        const loc  = this._resolveDocLocation(doc);
+        if (!loc) return null;
+        // Issue #97: never auto-leak the content of files outside the workspace
+        // into the prompt. The chip is still shown so the user is aware of the
+        // file; if they want to include it they must explicitly attach via the
+        // right-click command or the `#file` picker.
+        if (loc.external) return null;
         const sel  = editor.selection;
         const lang = doc.languageId;
-        const root = wsRoot();
-        const abs  = doc.fileName;
-        const rel  = root && abs.startsWith(root)
-            ? path.relative(root, abs).replace(/\\/g, '/')
-            : path.basename(abs);
+        const rel  = loc.rel;
         const lines = ['<attachments>'];
         lines.push(`The user is currently viewing \`${rel}\` (${lang}).`);
         if (!sel.isEmpty) {

--- a/src/chat/provider.js
+++ b/src/chat/provider.js
@@ -16,7 +16,7 @@ const path   = require('path');
 const fs     = require('fs');
 
 const { Logger }           = require('../logger');
-const { wsRoot, resolvePath, isInsideWorkspace, findContainingFolder } = require('../utils/paths');
+const { wsRoot, resolvePath, findContainingFolder } = require('../utils/paths');
 const { isZh }             = require('../utils/i18n');
 const { openFile }         = require('./openFile');
 const { buildWebviewHtml } = require('../webview/html');

--- a/src/extension.js
+++ b/src/extension.js
@@ -241,19 +241,29 @@ function activate(context) {
     );
 
     // Auto-attach live selection chip when the user selects text in any editor
+    // Issue #97: previously the empty-selection branch called clearLiveSelection,
+    // which hid the chip the moment the user clicked into a file without dragging
+    // a selection. We now keep the file chip (the provider supports a "no range"
+    // variant) and only clear when the editor itself is gone.
     let _selDebounce = null;
     context.subscriptions.push(
         vscode.window.onDidChangeTextEditorSelection(e => {
             if (_selDebounce) clearTimeout(_selDebounce);
             _selDebounce = setTimeout(() => {
                 _selDebounce = null;
-                const sel = e.selections && e.selections[0];
-                if (sel && !sel.isEmpty) {
-                    chatProvider.attachLiveSelection(e.textEditor);
-                } else {
-                    chatProvider.clearLiveSelection();
-                }
+                chatProvider.attachLiveSelection(e.textEditor);
             }, 300);
+        })
+    );
+
+    // Issue #97: react to active-editor changes (Ctrl+Tab, Explorer click,
+    // closing the last tab, etc.). onDidChangeTextEditorSelection does NOT
+    // fire when only the active editor changes, so without this listener the
+    // chip was stuck on whichever editor last had a selection event.
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (editor) chatProvider.attachLiveSelection(editor);
+            else chatProvider.clearLiveSelection();
         })
     );
 

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -35,19 +35,57 @@ function resolvePath(p) {
 }
 
 /**
- * Determine whether `absPath` is inside the workspace root (or equal to it).
- * Uses path.relative + safe start checks so symbolic resolution does not
- * matter — we only consider lexical containment, since following symlinks
- * to escape the workspace is itself a signal we want to flag.
+ * Test whether `absPath` is lexically contained by `rootPath`. Uses
+ * path.relative so platform-specific normalization (case-insensitive on
+ * Windows, drive-letter handling) is delegated to Node. Symlinks are not
+ * resolved — following them to escape the boundary is itself a signal we
+ * want to flag at the caller.
  */
-function isInsideWorkspace(absPath) {
-    const root = wsRoot();
-    if (!root) return false;
-    const rel = path.relative(root, absPath);
+function _isContainedBy(absPath, rootPath) {
+    if (!rootPath) return false;
+    const rel = path.relative(rootPath, absPath);
     if (!rel) return true; // exact root
     if (rel.startsWith('..')) return false;
     if (path.isAbsolute(rel)) return false; // different drive on Windows
     return true;
 }
 
-module.exports = { wsRoot, resolvePath, isInsideWorkspace, expandHome };
+/**
+ * Find the workspace folder that contains `absPath`.
+ *
+ * Issue #97: in a multi-root workspace, the first folder is not the only
+ * valid root. Callers that need to label a file relative to its owning
+ * folder (e.g. chat context chips) must walk *all* `workspaceFolders` and
+ * pick the one that lexically contains the path. Returns `null` when the
+ * path is outside every folder (an "external" file).
+ *
+ * @param {string} absPath
+ * @returns {{ folder: import('vscode').WorkspaceFolder, rel: string } | null}
+ */
+function findContainingFolder(absPath) {
+    if (!absPath) return null;
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) return null;
+    // Iterate longest-first so that nested folders win over their parents
+    // (rare, but possible when a user adds both a repo and one of its
+    // subdirectories as roots).
+    const sorted = [...folders].sort((a, b) => b.uri.fsPath.length - a.uri.fsPath.length);
+    for (const folder of sorted) {
+        const root = folder.uri.fsPath;
+        if (_isContainedBy(absPath, root)) {
+            const rel = path.relative(root, absPath).replace(/\\/g, '/');
+            return { folder, rel };
+        }
+    }
+    return null;
+}
+
+/**
+ * Determine whether `absPath` is inside *any* workspace folder.
+ * Multi-root aware (#97).
+ */
+function isInsideWorkspace(absPath) {
+    return findContainingFolder(absPath) !== null;
+}
+
+module.exports = { wsRoot, resolvePath, isInsideWorkspace, expandHome, findContainingFolder };


### PR DESCRIPTION
Closes #97 (Phase 1 + Phase 2)

## 改动概览

围绕 context chip「自动感知 + 多根工作区 + 外部文件」实现 issue #97 的前两个阶段，5 个文件、150 行净变更。第 3 阶段（reference 模型重构）按 issue 中建议留待独立 PR。

## Phase 1：自动感知当前文件

**`src/extension.js`**
- 新增 `vscode.window.onDidChangeActiveTextEditor` 监听，切换 tab / 从 Explorer 打开文件 / 关闭最后一个编辑器都会触发 chip 更新。
- 把原选区监听的 `else { clearLiveSelection() }` 分支改为也调用 `attachLiveSelection(e.textEditor)`，让 provider 内已存在的「空选区 = 整文件 chip」分支真正生效。

**`src/chat/provider.js`**
- `_onMessage('ready')` 处理里追加一次 `attachLiveSelection(activeTextEditor)` 调用，覆盖「插件刚激活、webview 第一次打开」的边缘情况，chip 不再是空的。

## Phase 2：多根工作区 + 外部文件

**`src/utils/paths.js`**
- 新增 `findContainingFolder(absPath) -> { folder, rel } | null`，遍历**所有** `workspaceFolders` 找出包含该路径的根（按路径长度降序，保证嵌套 root 时较深的优先命中）。
- `isInsideWorkspace` 改为基于上面这个 helper，自动获得多根支持。这是一个纯加宽的 bug 修复——以前 workspace folder 2..N 下的文件会被判定为「工作区外」，写入工具、`#file` picker、chip 全部受影响。
- 抽出 `_isContainedBy(abs, root)` 内部 helper，集中 lexical containment 逻辑。

**`src/chat/provider.js`**
- 抽出 `_resolveDocLocation(doc)`，集中处理：
  - 拒绝合成 scheme（保留 `file` / `untitled`）
  - 多根工作区：`rel` 相对于命中的 folder，不再统一相对 `folders[0]`
  - 外部文件：`external: true`，`rel` 退化为绝对路径
- `attachLiveSelection`、`attachSelection`、`_buildAttachmentBlock` 全部复用同一 helper。
- **外部文件策略**：
  - chip **显示**（用户能看到自己开了什么）。
  - `_buildAttachmentBlock` 对外部文件返回 `null`，不自动注入到 prompt。
  - 右键 `Attach Selection` 命令现在允许外部文件——用户显式意图，仍走 `addAttachment` 通道，payload 带 `external: true` 让 UI 区分样式。
  - 之前那条「只能附加工作区内的文件」warning 已移除。

**`media/chat.js`**
- `setLiveSelection` 处理 `external` 字段，保存到 `liveSelection.external`。
- `renderChips` 给外部 chip 加 `chip-external` class + 显示绝对路径的 tooltip（带「外部文件, 不自动附带」提示）。
- 发送时过滤：`liveSelection.content && !liveSelection.external` 才推入 attachments 数组，与 provider 侧的 `_buildAttachmentBlock` 跳过外部一致，**双重保险**杜绝外部文件自动入 prompt。

**`media/chat.css`**
- 新增 `.chip-external`：虚线边框 + 0.65 opacity + 透明背景，视觉上区别于实色的隐式 chip。

## 安全边界（未放宽）

| 通道 | 工作区内 | 工作区外 |
|---|---|---|
| chip 显示 | ✅ | ✅（虚线样式 + 绝对路径） |
| 自动注入 prompt | ✅ | ❌（provider + webview 双重过滤） |
| 显式 `Attach Selection` | ✅ | ✅（用户意图） |
| `#file` picker | 走 `context-refs.js` 既有审批路径 | 同左 |
| `write_file` / `apply_patch` | ✅ | ❌（`isInsideWorkspace` 守护，多根扩展后**仍**只允许工作区内）|
| 工具读取外部路径 | 走 `tools/utils.js ensurePathAllowed` 既有审批 | 同左 |

## 验收清单

- [x] 从资源管理器双击工作区文件，不选文本 → chip 立即出现（实色，无 range）。
- [x] 拖选若干行 → 同一 chip 追加 `:Lx-Ly` 标记。
- [x] 取消选区 → chip 保留为整文件，不再消失。
- [x] `Ctrl+Tab` 切换文件 → chip 自动跟随。
- [x] 关闭所有编辑器 → chip 消失。
- [x] 多根工作区：第 2 根下的文件 chip 正常显示，路径相对那一根。
- [x] 打开 `node_modules` 或工作区外文件 → chip 显示但样式为虚线低饱和，发送时不自动带入 prompt。
- [x] 右键 `Deep Copilot: Attach Selection` 在外部文件上也可用，显式附加成功。
- [x] webview 首次打开就显示当前活动编辑器 chip，无需先点击编辑器。
- [x] 无新增 lint / 编译错误（CSS 的 `user-select` 警告全部是 pre-existing 与本 PR 无关）。

## 不在本 PR 范围

按 issue 中阶段 3 的建议留待独立 PR：

- chip payload 从「正文 + 截断」改为「URI + range」引用模型，发送时按需 `readFile`。这需要协议级变更，单独审议更稳妥。
- chip 上的「眼睛」按钮（临时禁用 / 启用），以及 implicit / explicit chip 的两层样式区分。
- 大文件截断 ⚠ 角标。
