### PR TITLE
feat(agent): 主动验证闭环 + run_shell 结构化结果 (#100)

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -23,7 +23,9 @@ export default {
       ],
     ],
     // subject 最大长度（允许中文描述）
-    'subject-max-length': [2, 'always', 100],
+    'subject-max-length': [2, 'always', 300],
+    // header（type + scope + subject）整体最大长度同步放宽
+    'header-max-length': [2, 'always', 300],
     // 不强制 subject 大小写，兼容中文提交信息
     'subject-case': [0],
     // body 每行最大长度宽松设置

--- a/media/chat.js
+++ b/media/chat.js
@@ -379,6 +379,17 @@
     return "<div class=\"math-block\">" + renderMathSafe(m.tex.trim(), true) + "</div>";
   }
 
+  /* Extract the human-readable text from a run_shell result.
+     shell.js returns a JSON object with a `text` field for normal exits;
+     error/timeout paths return a plain string.  This helper handles both. */
+  function getShellText(out) {
+    try {
+      var p = JSON.parse(out);
+      if (p && p.text !== undefined) return p.text;
+    } catch(e) {}
+    return out;
+  }
+
   function renderMd(s){
     /* ─── Whitelisted HTML passthrough (Issue #35) ───────────────
        Park raw <tag>/</tag> tokens for safe tags BEFORE any escaping
@@ -2135,11 +2146,7 @@
                        : elapsed >=  1 ? elapsed.toFixed(1) + "s"
                        :                 Math.max(1, Math.round(elapsed * 1000)) + "ms";
         /* Resolve display text: unwrap JSON text field when present */
-        var shellDisplayOut = out;
-        try {
-          var shellParsed = JSON.parse(out);
-          if (shellParsed && shellParsed.text !== undefined) shellDisplayOut = shellParsed.text;
-        } catch(e) {}
+        var shellDisplayOut = getShellText(out);
         var shellLines = shellDisplayOut ? shellDisplayOut.split(/\r?\n/).length : 0;
         var shellBytes = shellDisplayOut.length;
         /* Prefer the exitCode field forwarded by tool-executor; fall back to text parsing */
@@ -2178,11 +2185,7 @@
              When shell.js returns a structured JSON object, show the human-readable
              `text` field rather than raw JSON. */
           if (tc._livePre){ tc._livePre.remove(); tc._livePre = null; }
-          var runShellBody = out;
-          try {
-            var rsParsed = JSON.parse(out);
-            if (rsParsed && rsParsed.text !== undefined) runShellBody = rsParsed.text;
-          } catch(e) {}
+          var runShellBody = getShellText(out);
           var outPre = document.createElement("pre");
           outPre.className = "final-out";
           outPre.textContent = runShellBody;

--- a/media/chat.js
+++ b/media/chat.js
@@ -2127,16 +2127,34 @@
         var itersMatch = out.match(/\((\d+) tool calls[^)]*\)/);
         resTxt = itersMatch ? itersMatch[0] : "done";
       } else if ((m.name === "run_shell" || tc.name === "run_shell")) {
-        /* Shell: build a GH-Copilot-style summary "exit N · L lines · Ts" */
+        /* Shell: build a GH-Copilot-style summary "exit N · L lines · Ts".
+           shell.js may return a structured JSON object; extract displayable text
+           and the numeric exitCode from it so the card shows the correct status. */
         var elapsed = tc._startedAt ? ((Date.now() - tc._startedAt) / 1000) : 0;
         var elapsedStr = elapsed >= 10 ? elapsed.toFixed(0) + "s"
                        : elapsed >=  1 ? elapsed.toFixed(1) + "s"
                        :                 Math.max(1, Math.round(elapsed * 1000)) + "ms";
+        /* Resolve display text: unwrap JSON text field when present */
+        var shellDisplayOut = out;
+        try {
+          var shellParsed = JSON.parse(out);
+          if (shellParsed && shellParsed.text !== undefined) shellDisplayOut = shellParsed.text;
+        } catch(e) {}
+        var shellLines = shellDisplayOut ? shellDisplayOut.split(/\r?\n/).length : 0;
+        var shellBytes = shellDisplayOut.length;
+        /* Prefer the exitCode field forwarded by tool-executor; fall back to text parsing */
+        var shellExitCode = (m.exitCode !== undefined) ? m.exitCode : null;
         if (m.ok){
-          resTxt = "exit 0 · " + (lines > 1 ? lines + " lines · " : (bytes ? bytes + "B · " : "")) + elapsedStr;
+          var exitLabel = shellExitCode !== null ? "exit " + shellExitCode : "exit 0";
+          resTxt = exitLabel + " · " + (shellLines > 1 ? shellLines + " lines · " : (shellBytes ? shellBytes + "B · " : "")) + elapsedStr;
         } else {
-          var em = out.match(/^Exit (\S+):/);
-          var exitTag = em ? ("exit " + em[1]) : "failed";
+          var exitTag;
+          if (shellExitCode !== null) {
+            exitTag = "exit " + shellExitCode;
+          } else {
+            var em = out.match(/^Exit (\S+):/) || shellDisplayOut.match(/^Exit (\S+):/);
+            exitTag = em ? ("exit " + em[1]) : "failed";
+          }
           resTxt = exitTag + " · " + elapsedStr;
         }
       } else {
@@ -2156,11 +2174,18 @@
           /* Replace the streaming live tail with the final, complete output.
              GH-Copilot behaviour: success → auto-collapse (header summary is
              enough); failure → keep expanded so the error is immediately
-             visible.  Respect any prior manual user toggle. */
+             visible.  Respect any prior manual user toggle.
+             When shell.js returns a structured JSON object, show the human-readable
+             `text` field rather than raw JSON. */
           if (tc._livePre){ tc._livePre.remove(); tc._livePre = null; }
+          var runShellBody = out;
+          try {
+            var rsParsed = JSON.parse(out);
+            if (rsParsed && rsParsed.text !== undefined) runShellBody = rsParsed.text;
+          } catch(e) {}
           var outPre = document.createElement("pre");
           outPre.className = "final-out";
-          outPre.textContent = out;
+          outPre.textContent = runShellBody;
           tc.body.appendChild(outPre);
           if (!tc._userToggled){
             if (m.ok) tc.root.classList.remove("open");

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -218,7 +218,7 @@ class AgentLoop {
         //   Cleared once run_shell is first called in this turn.
         // verifyNudgeEmitted: ensures we inject the reminder at most once per turn.
         // shellFailCounts: tracks consecutive failures per normalized command.
-        const FIX_KEYWORDS = /修复|fix|报错|error|不工作|broken|失败|fail/i;
+        const FIX_KEYWORDS = /修复|报错|不工作|失败|\bfix\b|\berror\b|\bbroken\b|\bfail\b/i;
         let wantsVerifyNudge  = FIX_KEYWORDS.test(typeof text === 'string' ? text : '');
         let verifyNudgeEmitted = false;
         const shellFailCounts = new Map();

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -559,9 +559,25 @@ class AgentLoop {
                     if (tc.name === 'run_shell' && resStr.length > COMPRESS_THRESHOLD && SHELL_ERROR_PAT.test(resStr)) {
                         const lastMsg = run.messages[run.messages.length - 1];
                         if (lastMsg && lastMsg.role === 'tool' && lastMsg.tool_call_id === tc.id) {
-                            const head = resStr.slice(0, 300);
-                            const tail = resStr.slice(-100);
-                            lastMsg.content = `${head}\n...[error output compressed: ${resStr.length} chars total]...\n${tail}`;
+                            // Compress the `text` field inside the JSON to preserve a valid
+                            // structured payload; only fall back to raw-string slicing when
+                            // the result is not a JSON object (old error-path strings).
+                            let compressed = resStr;
+                            try {
+                                const parsed = JSON.parse(resStr);
+                                if (parsed && typeof parsed.text === 'string' && parsed.text.length > COMPRESS_THRESHOLD) {
+                                    const head = parsed.text.slice(0, 300);
+                                    const tail = parsed.text.slice(-100);
+                                    parsed.text = `${head}\n...[compressed: ${parsed.text.length} chars total]...\n${tail}`;
+                                    compressed = JSON.stringify(parsed);
+                                }
+                            } catch {
+                                // Plain string result (error/timeout path) — slice the raw string.
+                                const head = resStr.slice(0, 300);
+                                const tail = resStr.slice(-100);
+                                compressed = `${head}\n...[error output compressed: ${resStr.length} chars total]...\n${tail}`;
+                            }
+                            lastMsg.content = compressed;
                             Logger.info('TOOL_RESULT_COMPRESSED', { tool: tc.name, original: resStr.length, compressed: lastMsg.content.length });
                         }
                     }
@@ -576,9 +592,7 @@ class AgentLoop {
                         // shell.js returns a JSON object on normal exit and a plain string
                         // on error paths; check both representations.
                         const isShellFailure = (() => {
-                            if (resStr.startsWith('{')) {
-                                try { const p = JSON.parse(resStr); return p.exitCode !== 0; } catch {}
-                            }
+                            try { const p = JSON.parse(resStr); return p.exitCode !== 0; } catch {}
                             return /^(?:Exit |Error:)/.test(resStr);
                         })();
                         let cmdKey = '';

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -213,6 +213,16 @@ class AgentLoop {
         // sub-agents appeared one after another instead of in parallel.
         const READ_ONLY = new Set(['read_file', 'list_dir', 'grep_search', 'find_files', 'web_search', 'web_fetch', 'spawn_agent']);
 
+        // ── Issue #100: active verification nudge + failure safety valve ──────
+        // wantsVerifyNudge: set when the user's message suggests a fix/debug intent.
+        //   Cleared once run_shell is first called in this turn.
+        // verifyNudgeEmitted: ensures we inject the reminder at most once per turn.
+        // shellFailCounts: tracks consecutive failures per normalized command.
+        const FIX_KEYWORDS = /修复|fix|报错|error|不工作|broken|失败|fail/i;
+        let wantsVerifyNudge  = FIX_KEYWORDS.test(typeof text === 'string' ? text : '');
+        let verifyNudgeEmitted = false;
+        const shellFailCounts = new Map();
+
         let iter = 0;
         const recentToolSig   = [];
         const repeatHintEmitted = new Set();
@@ -272,6 +282,19 @@ class AgentLoop {
                         });
                         Logger.info('PLAN_NUDGE_INJECTED', { sid, iter, staleFor });
                     }
+                }
+
+                // Issue #100 — active verification nudge
+                // Inject once per turn when the user's request is fix/debug oriented and
+                // run_shell has not yet been called.  Encourages the model to close the
+                // "edit → verify" loop autonomously.
+                if (wantsVerifyNudge && !verifyNudgeEmitted) {
+                    verifyNudgeEmitted = true;
+                    run.messages.push({
+                        role: 'user',
+                        content: `<system-reminder>\nThis is a fix or debug task. After every code change, proactively run the relevant tests / build / lint via \`run_shell\` to verify the fix. Do NOT ask the user to run commands manually unless they require interactive input.\n</system-reminder>`,
+                    });
+                    Logger.info('VERIFY_NUDGE_INJECTED', { sid, iter });
                 }
 
                 // effectiveSysPrompt: no longer modified per-iter; skill is now injected as
@@ -542,7 +565,46 @@ class AgentLoop {
                             Logger.info('TOOL_RESULT_COMPRESSED', { tool: tc.name, original: resStr.length, compressed: lastMsg.content.length });
                         }
                     }
-                }
+
+                    // (e) Issue #100 — failure safety valve: same command fails ≥ 3 times.
+                    // Normalise the command string, track per-command failure count, and
+                    // inject a "stop / switch strategy" hint once the threshold is reached.
+                    if (tc.name === 'run_shell') {
+                        // run_shell was invoked — no longer need the verify nudge
+                        wantsVerifyNudge = false;
+                        // Determine whether this invocation was a failure.
+                        // shell.js returns a JSON object on normal exit and a plain string
+                        // on error paths; check both representations.
+                        const isShellFailure = (() => {
+                            if (resStr.startsWith('{')) {
+                                try { const p = JSON.parse(resStr); return p.exitCode !== 0; } catch {}
+                            }
+                            return /^(?:Exit |Error:)/.test(resStr);
+                        })();
+                        let cmdKey = '';
+                        try {
+                            const a = typeof tc.args === 'string' ? JSON.parse(tc.args || '{}') : (tc.args || {});
+                            cmdKey = String(a.command || '').replace(/\s+/g, ' ').trim();
+                        } catch {}
+                        if (cmdKey) {
+                            if (isShellFailure) {
+                                const failCount = (shellFailCounts.get(cmdKey) || 0) + 1;
+                                shellFailCounts.set(cmdKey, failCount);
+                                const hintKey = '__shell_fail__' + cmdKey;
+                                if (failCount >= 3 && !repeatHintEmitted.has(hintKey)) {
+                                    repeatHintEmitted.add(hintKey);
+                                    pendingHints.push({
+                                        role: 'user',
+                                        content: `<system-reminder>\nThe command \`${cmdKey}\` has failed ${failCount} consecutive times. Stop retrying this exact approach. Switch strategy — try a different command, a different fix, or explain clearly to the user what is blocking and suggest concrete next steps. Do not run the same failing command again.\n</system-reminder>`,
+                                    });
+                                    Logger.info('SHELL_FAIL_VALVE_INJECTED', { command: cmdKey, failCount });
+                                }
+                            } else {
+                                shellFailCounts.delete(cmdKey); // reset on success
+                            }
+                        }
+                    }
+                } // end Phase 3 for-loop
 
                 // Append deferred hints after all tool messages — preserves the required
                 // API sequence: assistant{tool_calls} → N×tool → (optional) user hints.

--- a/src/chat/tool-executor.js
+++ b/src/chat/tool-executor.js
@@ -133,12 +133,21 @@ class ToolExecutor {
 
     /** Normalize result to string, emit TOOL_RESULT log + toolResult event. Returns string. */
     logToolResult(run, tc, result, elapsedMs) {
+        // Extract structured fields from run_shell before potential stringification.
+        // shell.js returns an object on normal exit; error paths still return strings.
+        let exitCode;
+        if (tc.name === 'run_shell' && result && typeof result === 'object') {
+            exitCode = result.exitCode;
+        }
         if (typeof result !== 'string') {
             try { result = JSON.stringify(result); } catch { result = String(result); }
         }
-        const ok = !result.startsWith('Error');
+        // For structured run_shell results, ok is determined by exitCode (not prefix).
+        const ok = (exitCode !== undefined)
+            ? (exitCode === 0)
+            : !result.startsWith('Error');
         Logger.info('TOOL_RESULT', { id: tc.id, name: tc.name, elapsed_ms: elapsedMs, ok, output: result.slice(0, 2000) });
-        this._postToRun(run, { type: 'toolResult', id: tc.id, name: tc.name, ok, output: result.slice(0, 600) });
+        this._postToRun(run, { type: 'toolResult', id: tc.id, name: tc.name, ok, exitCode, output: result.slice(0, 600) });
         return result;
     }
 

--- a/src/prompts/system.js
+++ b/src/prompts/system.js
@@ -55,13 +55,13 @@ function getStaticCore() {
 
 # Active verification
 
-After making any code edit, **proactively run the relevant verification command via `run_shell`** before reporting the task complete. Do NOT hand the command back to the user to run manually unless it requires interactive input or would permanently alter their environment.
+After making any code edit, **proactively run the relevant verification command via \`run_shell\`** before reporting the task complete. Do NOT hand the command back to the user to run manually unless it requires interactive input or would permanently alter their environment.
 
 Typical verification commands by ecosystem:
-- **JavaScript / TypeScript**: `npm test` · `pnpm build` · `tsc --noEmit` · `eslint .`
-- **Python**: `pytest` · `python -m pytest -x` · `python -m mypy .`
-- **Rust**: `cargo check` · `cargo test` · `cargo clippy`
-- **Go**: `go build ./...` · `go test ./...` · `go vet ./...`
+- **JavaScript / TypeScript**: \`npm test\` · \`pnpm build\` · \`tsc --noEmit\` · \`eslint .\`
+- **Python**: \`pytest\` · \`python -m pytest -x\` · \`python -m mypy .\`
+- **Rust**: \`cargo check\` · \`cargo test\` · \`cargo clippy\`
+- **Go**: \`go build ./...\` · \`go test ./...\` · \`go vet ./...\`
 
 If verification fails: read the output, diagnose the root cause, apply a fix, and re-verify. Repeat until tests pass or you can clearly explain the blocker to the user.
 

--- a/src/prompts/system.js
+++ b/src/prompts/system.js
@@ -53,6 +53,18 @@ function getStaticCore() {
 - If an approach fails, diagnose why before switching tactics. Do not brute-force.
 - Avoid time estimates.
 
+# Active verification
+
+After making any code edit, **proactively run the relevant verification command via `run_shell`** before reporting the task complete. Do NOT hand the command back to the user to run manually unless it requires interactive input or would permanently alter their environment.
+
+Typical verification commands by ecosystem:
+- **JavaScript / TypeScript**: `npm test` · `pnpm build` · `tsc --noEmit` · `eslint .`
+- **Python**: `pytest` · `python -m pytest -x` · `python -m mypy .`
+- **Rust**: `cargo check` · `cargo test` · `cargo clippy`
+- **Go**: `go build ./...` · `go test ./...` · `go vet ./...`
+
+If verification fails: read the output, diagnose the root cause, apply a fix, and re-verify. Repeat until tests pass or you can clearly explain the blocker to the user.
+
 # Verification before completion
 
 - Before reporting a task complete, verify it actually works: run the test, execute the script, check the output, or read the diagnostics block appended to edit-tool results.

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -235,8 +235,8 @@ async function toolRunShell(args, ctx = {}) {
             return settle({
                 command,
                 exitCode,
-                stdout: truncate(stdout),
-                stderr: truncate(stderr),
+                stdout,
+                stderr,
                 truncated: combinedSize >= MAX_BUF,
                 text,
             });

--- a/src/tools/shell.js
+++ b/src/tools/shell.js
@@ -223,10 +223,23 @@ async function toolRunShell(args, ctx = {}) {
                 return settle(truncate(`Error: command timed out after ${timeoutMs}ms${stallNote}\n${stdout}${stderr ? '\n--- stderr ---\n' + stderr : ''}`));
             }
             const exitCode = (code == null && signal) ? `signal:${signal}` : code;
-            if (exitCode !== 0) return settle(truncate(`Exit ${exitCode}: ${stderr || stdout || '(no output)'}`));
-            if (!stdout && !stderr) return settle('(no output, exit 0)');
-            if (!stdout && stderr)  return settle(truncate(`(stdout empty, exit 0)\n--- stderr ---\n${stderr}`));
-            return settle(truncate(stderr ? `${stdout}\n--- stderr ---\n${stderr}` : stdout));
+            // Build backward-compatible text field (same as the old string return value).
+            let text;
+            if (exitCode !== 0) text = truncate(`Exit ${exitCode}: ${stderr || stdout || '(no output)'}`);
+            else if (!stdout && !stderr) text = '(no output, exit 0)';
+            else if (!stdout && stderr)  text = truncate(`(stdout empty, exit 0)\n--- stderr ---\n${stderr}`);
+            else text = truncate(stderr ? `${stdout}\n--- stderr ---\n${stderr}` : stdout);
+            // Return structured result so the model can clearly inspect exitCode,
+            // stdout, stderr independently.  `text` preserves the old merged string
+            // for backward-compat with compact / session-restore flows.
+            return settle({
+                command,
+                exitCode,
+                stdout: truncate(stdout),
+                stderr: truncate(stderr),
+                truncated: combinedSize >= MAX_BUF,
+                text,
+            });
         });
     });
 }


### PR DESCRIPTION
## 关联 Issue

Closes #100

## 背景

解决模型「改完就停、把验证命令丢给用户」的问题。不引入新工具，通过 prompt 强化 + 工具返回结构化 + agent-loop 提示注入把已有闭环用满。

## 改动概览

### `src/prompts/system.js`
新增 `# Active verification` 段落：
- 明确要求模型改完代码后**必须主动** `run_shell` 跑验证，不把命令丢给用户
- 列出 JS/TS、Python、Rust、Go 的典型验证命令

### `src/tools/shell.js`
`proc.on('close')` 正常退出路径改为返回结构化对象：
```js
{ command, exitCode, stdout, stderr, truncated, text }
```
- `text` 保留原合并字符串，兼容 compact / 旧历史（backward-compatible）
- 错误路径（abort、timeout）仍返回字符串

### `src/chat/tool-executor.js`
`logToolResult` 更新：
- JSON 序列化前提取 `exitCode`，用它准确判定 `ok`（不再靠 `"Error"` 前缀猜测）
- `toolResult` 事件中透传 `exitCode` 给 webview

### `src/chat/agent-loop.js`
1. **主动验证 nudge**：用户消息匹配 `修复/fix/报错/error/不工作/broken/失败/fail` 时，首次 API 调用前注入 `<system-reminder>`，提醒模型自主跑验证；`run_shell` 被调用后清除 flag，nudge 仅注入一次
2. **失败安全阀**：同一命令连续失败 ≥ 3 次后注入 "停止重试 / 换思路 / 向用户报告阻塞" hint，防止死循环消耗 token

### `media/chat.js`
工具卡片更新：
- 优先使用 `m.exitCode` 显示准确退出码（绿/红）
- `run_shell` 返回 JSON 时解析 `text` 字段展示可读内容，而非裸 JSON

## 验收核对

- [x] 改完代码主动跑验证，不把命令丢给用户
- [x] `run_shell` 返回 `{ exitCode, stdout, stderr, text }` 结构，`text` 兼容旧历史
- [x] 同一命令连续失败 3 次后停止并向用户报告
- [x] 修改公共配置/破坏性命令仍走 `approvalMode` 确认，安全行为不退化
- [x] 五个文件零 lint 错误