### PR TITLE
feat: add Anthropic (Claude) provider support

### DIFF
--- a/media/chat.js
+++ b/media/chat.js
@@ -41,23 +41,30 @@
       { value: "gemini-2.0-flash", name: "gemini-2.0-flash", desc: "Gemini 2.0 Flash — 快速" },
       { value: "gemini-1.5-pro",   name: "gemini-1.5-pro",   desc: "Gemini 1.5 Pro — 强大" },
     ],
+    anthropic: [
+      { value: "claude-opus-4-7",          name: "claude-opus-4-7",          desc: "Claude Opus 4.7 — 最强旗舰" },
+      { value: "claude-sonnet-4-6",        name: "claude-sonnet-4-6",        desc: "Claude Sonnet 4.6 — 均衡推荐" },
+      { value: "claude-haiku-4-5-20251001",name: "claude-haiku-4-5",         desc: "Claude Haiku 4.5 — 快速轻量" },
+    ],
     custom: [],
   };
   var PROVIDER_URLS = {
-    deepseek: 'https://api.deepseek.com',
-    openai:   'https://api.openai.com/v1',
-    groq:     'https://api.groq.com/openai/v1',
-    ollama:   'http://localhost:11434/v1',
-    gemini:   'https://generativelanguage.googleapis.com/v1beta/openai/',
-    custom:   '',
+    deepseek:  'https://api.deepseek.com',
+    openai:    'https://api.openai.com/v1',
+    groq:      'https://api.groq.com/openai/v1',
+    ollama:    'http://localhost:11434/v1',
+    gemini:    'https://generativelanguage.googleapis.com/v1beta/openai/',
+    anthropic: 'https://api.anthropic.com',
+    custom:    '',
   };
   var PROVIDER_KEY_LINKS = {
-    deepseek: 'https://platform.deepseek.com/api_keys',
-    openai:   'https://platform.openai.com/api-keys',
-    groq:     'https://console.groq.com/keys',
-    ollama:   null,
-    gemini:   'https://aistudio.google.com/app/apikey',
-    custom:   null,
+    deepseek:  'https://platform.deepseek.com/api_keys',
+    openai:    'https://platform.openai.com/api-keys',
+    groq:      'https://console.groq.com/keys',
+    ollama:    null,
+    gemini:    'https://aistudio.google.com/app/apikey',
+    anthropic: 'https://console.anthropic.com/settings/keys',
+    custom:    null,
   };
   var MODELS = PROVIDER_MODELS.deepseek;
   var _currentProvider = 'deepseek';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deep-copilot",
       "version": "0.35.3",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.96.0",
         "openai": "^6.38.0"
       },
       "devDependencies": {
@@ -23,6 +24,27 @@
       },
       "engines": {
         "vscode": "^1.95.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -191,6 +213,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -996,6 +1027,12 @@
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.40",
@@ -2515,6 +2552,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3115,6 +3158,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4399,6 +4455,16 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4557,6 +4623,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
             "groq",
             "ollama",
             "gemini",
+            "anthropic",
             "custom"
           ],
           "enumDescriptions": [
@@ -169,6 +170,7 @@
             "Groq — api.groq.com/openai/v1 (fast Llama/Mixtral, no streaming usage)",
             "Ollama — localhost:11434/v1 (local, no API key required)",
             "Google Gemini (OpenAI-compat endpoint)",
+            "Anthropic — api.anthropic.com (Claude models, native SDK)",
             "Custom — use the Base URL configured above"
           ],
           "description": "AI provider. Selecting a preset auto-fills the Base URL in the settings UI."
@@ -360,6 +362,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.96.0",
     "openai": "^6.38.0"
   },
   "devDependencies": {

--- a/src/api/adapter.js
+++ b/src/api/adapter.js
@@ -1,18 +1,21 @@
 'use strict';
 
 const { streamChat: streamChatBase, fetchBalance } = require('./openai-client');
+const { streamChat: streamChatAnthropic }          = require('./anthropic-client');
 
 // Preset configuration per provider.
 // streamOptions: whether to send stream_options.include_usage (true = supported).
 // parallelTools: whether to send parallel_tool_calls (true = supported).
 // noApiKey:      provider does not require an API key (e.g. local Ollama).
+// isAnthropic:   routes to the native Anthropic SDK client instead of OpenAI-compatible.
 const PROVIDER_PRESETS = {
-  deepseek: { baseUrl: 'https://api.deepseek.com',                              defaultModel: 'deepseek-v4-pro', streamOptions: true,  parallelTools: true  },
-  openai:   { baseUrl: 'https://api.openai.com/v1',                             defaultModel: 'gpt-4o',          streamOptions: true,  parallelTools: true  },
-  groq:     { baseUrl: 'https://api.groq.com/openai/v1',                        defaultModel: 'llama-3.3-70b-versatile', streamOptions: false, parallelTools: false },
-  ollama:   { baseUrl: 'http://localhost:11434/v1',                             defaultModel: 'llama3.2',        streamOptions: false, parallelTools: false, noApiKey: true },
-  gemini:   { baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/', defaultModel: 'gemini-2.0-flash', streamOptions: false, parallelTools: false },
-  custom:   { streamOptions: false, parallelTools: false },
+  deepseek:  { baseUrl: 'https://api.deepseek.com',                               defaultModel: 'deepseek-v4-pro',         streamOptions: true,  parallelTools: true  },
+  openai:    { baseUrl: 'https://api.openai.com/v1',                              defaultModel: 'gpt-4o',                  streamOptions: true,  parallelTools: true  },
+  groq:      { baseUrl: 'https://api.groq.com/openai/v1',                         defaultModel: 'llama-3.3-70b-versatile', streamOptions: false, parallelTools: false },
+  ollama:    { baseUrl: 'http://localhost:11434/v1',                              defaultModel: 'llama3.2',                streamOptions: false, parallelTools: false, noApiKey: true },
+  gemini:    { baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/', defaultModel: 'gemini-2.0-flash',      streamOptions: false, parallelTools: false },
+  anthropic: { baseUrl: 'https://api.anthropic.com',                              defaultModel: 'claude-sonnet-4-6',       isAnthropic: true,   streamOptions: false, parallelTools: false },
+  custom:    { streamOptions: false, parallelTools: false },
 };
 
 /**
@@ -21,11 +24,10 @@ const PROVIDER_PRESETS = {
  */
 function shouldUseOverrideModel(provider, overrideModel) {
   if (!overrideModel) return false;
-  // If the model looks like it belongs to a different provider, ignore it.
-  // Specifically: deepseek-* models on non-deepseek providers.
-  if (provider !== 'deepseek' && String(overrideModel).startsWith('deepseek-')) {
-    return false;
-  }
+  const m = String(overrideModel);
+  // Ignore provider-specific model names when the provider doesn't match.
+  if (provider !== 'deepseek'  && m.startsWith('deepseek-'))  return false;
+  if (provider !== 'anthropic' && m.startsWith('claude-'))    return false;
   return true;
 }
 
@@ -52,10 +54,21 @@ function resolveProviderConfig(provider, overrideBaseUrl, overrideModel) {
 
 /**
  * Route a chat streaming request through the correct provider configuration.
- * Reads `provider` from params, resolves baseUrl/model/flags, then delegates
- * to the OpenAI-compatible client.
+ * Anthropic uses its own native SDK client; all others use the OpenAI-compatible client.
  */
 function streamChat({ provider, apiKey, baseUrl, model, ...rest }, callbacks, abortSignal) {
+  const preset = PROVIDER_PRESETS[provider] || PROVIDER_PRESETS.custom;
+
+  if (preset.isAnthropic) {
+    const effectiveModel  = shouldUseOverrideModel(provider, model) ? model : (preset.defaultModel || 'claude-sonnet-4-6');
+    const effectiveUrl    = baseUrl || preset.baseUrl;
+    return streamChatAnthropic(
+      { ...rest, apiKey: apiKey || '', baseUrl: effectiveUrl, model: effectiveModel },
+      callbacks,
+      abortSignal,
+    );
+  }
+
   const resolved = resolveProviderConfig(provider || 'deepseek', baseUrl, model);
   // For providers that don't need an API key (Ollama), use a dummy value
   // so the OpenAI SDK doesn't reject the request.

--- a/src/api/anthropic-client.js
+++ b/src/api/anthropic-client.js
@@ -252,4 +252,28 @@ async function streamChat({ apiKey, baseUrl, messages, model, noTools, tools }, 
     return { toolCalls: Object.values(toolCalls), usage };
 }
 
-module.exports = { streamChat };
+/**
+ * Test an Anthropic API key by making a minimal non-streaming messages call.
+ * Returns { ok: true } on success or { ok: false, error: string } on failure.
+ */
+async function testConnection({ apiKey, baseUrl, model }) {
+    const client = new Anthropic({
+        apiKey:  apiKey || '',
+        ...(baseUrl ? { baseURL: baseUrl.replace(/\/$/, '') } : {}),
+    });
+    try {
+        await client.messages.create({
+            model:     model || 'claude-sonnet-4-6',
+            max_tokens: 1,
+            messages:  [{ role: 'user', content: 'hi' }],
+        });
+        return { ok: true };
+    } catch (err) {
+        const detail = err.error
+            ? (typeof err.error === 'object' ? JSON.stringify(err.error) : String(err.error))
+            : '';
+        return { ok: false, error: err.message || detail || `HTTP ${err.status || 'unknown'}` };
+    }
+}
+
+module.exports = { streamChat, testConnection };

--- a/src/api/anthropic-client.js
+++ b/src/api/anthropic-client.js
@@ -1,0 +1,255 @@
+'use strict';
+
+// Anthropic (Claude) streaming client.
+// The Anthropic API is NOT OpenAI-compatible, so this is a separate implementation
+// that converts between the extension's internal OpenAI-format messages and
+// Anthropic's native message format, then streams back in the same shape as
+// openai-client.js so the rest of the codebase is unaffected.
+
+const Anthropic = require('@anthropic-ai/sdk');
+const { Logger } = require('../logger');
+
+// Convert OpenAI-format tool definitions → Anthropic format
+function convertTools(openaiTools) {
+    if (!Array.isArray(openaiTools)) return [];
+    return openaiTools.map(t => {
+        const fn = t.function || {};
+        return {
+            name:         fn.name        || '',
+            description:  fn.description || '',
+            input_schema: fn.parameters  || { type: 'object', properties: {} },
+        };
+    });
+}
+
+// Convert OpenAI-format messages → Anthropic format.
+// Returns { system: string|undefined, messages: array }
+//
+// Key differences:
+//   - system role → top-level `system` parameter
+//   - role:'tool' messages → grouped into a single user message with tool_result blocks
+//   - assistant tool_calls → content blocks of type 'tool_use'
+//   - image_url content → Anthropic base64 image blocks
+function convertMessages(openaiMessages) {
+    let system;
+    const result = [];
+    let i = 0;
+
+    while (i < openaiMessages.length) {
+        const msg = openaiMessages[i];
+
+        if (msg.role === 'system') {
+            const text = typeof msg.content === 'string' ? msg.content : '';
+            system = system ? system + '\n\n' + text : text;
+            i++;
+            continue;
+        }
+
+        // Group consecutive tool result messages into one user message.
+        // Anthropic requires all tool results after an assistant turn to be
+        // in a single user message as an array of tool_result blocks.
+        if (msg.role === 'tool') {
+            const toolResults = [];
+            while (i < openaiMessages.length && openaiMessages[i].role === 'tool') {
+                const t = openaiMessages[i];
+                toolResults.push({
+                    type:        'tool_result',
+                    tool_use_id: t.tool_call_id,
+                    content:     String(t.content || ''),
+                });
+                i++;
+            }
+            result.push({ role: 'user', content: toolResults });
+            continue;
+        }
+
+        if (msg.role === 'assistant') {
+            const content = [];
+            // reasoning_content (DeepSeek thinking) is intentionally dropped here.
+            // Anthropic only accepts thinking blocks when extended thinking is enabled,
+            // so injecting them from a prior DeepSeek session would cause an API error.
+            if (msg.content) {
+                content.push({ type: 'text', text: typeof msg.content === 'string' ? msg.content : String(msg.content) });
+            }
+            if (Array.isArray(msg.tool_calls)) {
+                for (const tc of msg.tool_calls) {
+                    let input = {};
+                    try {
+                        const raw = tc.function ? tc.function.arguments : (tc.args || '{}');
+                        input = JSON.parse(raw);
+                    } catch { /* malformed args — leave as empty object */ }
+                    content.push({
+                        type:  'tool_use',
+                        id:    tc.id,
+                        name:  tc.function ? tc.function.name : (tc.name || ''),
+                        input,
+                    });
+                }
+            }
+            // Anthropic rejects empty content arrays
+            if (!content.length) content.push({ type: 'text', text: '' });
+            result.push({ role: 'assistant', content });
+            i++;
+            continue;
+        }
+
+        if (msg.role === 'user') {
+            let content;
+            if (Array.isArray(msg.content)) {
+                content = msg.content.map(block => {
+                    if (block.type === 'text') return { type: 'text', text: block.text };
+                    if (block.type === 'image_url') {
+                        const url = block.image_url && block.image_url.url;
+                        if (url && url.startsWith('data:')) {
+                            const match = url.match(/^data:([^;]+);base64,(.+)$/);
+                            if (match) {
+                                return {
+                                    type:   'image',
+                                    source: { type: 'base64', media_type: match[1], data: match[2] },
+                                };
+                            }
+                        }
+                        return { type: 'text', text: '[image unavailable]' };
+                    }
+                    return block;
+                });
+            } else {
+                content = typeof msg.content === 'string' ? msg.content : String(msg.content || '');
+            }
+            result.push({ role: 'user', content });
+            i++;
+            continue;
+        }
+
+        i++;
+    }
+
+    return { system, messages: result };
+}
+
+/**
+ * Stream a chat completion via the Anthropic SDK.
+ * Signature matches openai-client.js so adapter.js can call either transparently.
+ *
+ * @returns {Promise<{ toolCalls: Array<{id,name,args}>, usage: object|null }>}
+ */
+async function streamChat({ apiKey, baseUrl, messages, model, noTools, tools }, callbacks, abortSignal) {
+    const client = new Anthropic({
+        apiKey:  apiKey || '',
+        ...(baseUrl ? { baseURL: baseUrl.replace(/\/$/, '') } : {}),
+    });
+
+    const { system, messages: anthropicMessages } = convertMessages(messages);
+
+    const reqPayload = {
+        model:      model || 'claude-sonnet-4-6',
+        max_tokens: 16000,
+        messages:   anthropicMessages,
+    };
+    if (system) reqPayload.system = system;
+    if (!noTools && Array.isArray(tools) && tools.length) {
+        reqPayload.tools       = convertTools(tools);
+        reqPayload.tool_choice = { type: 'auto' };
+    }
+
+    const startedAt  = Date.now();
+    let firstByteAt  = 0;
+    let chunkCount   = 0;
+    const toolCalls  = {};  // keyed by block index
+    let usage        = null;
+
+    Logger.info('HTTP_REQUEST', { url: client.baseURL, model, msg_count: messages.length });
+
+    function normalizeError(err) {
+        if (err.name === 'AbortError' || err.message === 'aborted') return new Error('aborted');
+        if (err.status) {
+            const detail = err.error
+                ? (typeof err.error === 'object' ? JSON.stringify(err.error) : String(err.error))
+                : '';
+            Logger.info('HTTP_ERROR', { status: err.status, body: detail || err.message });
+            const apiErr = new Error(`API ${err.status}: ${err.message}${detail ? '\n\n' + detail : ''}`);
+            apiErr.statusCode = err.status;
+            apiErr.body       = detail || err.message;
+            return apiErr;
+        }
+        return err;
+    }
+
+    let stream;
+    try {
+        stream = await client.messages.create(
+            { ...reqPayload, stream: true },
+            { signal: abortSignal },
+        );
+    } catch (err) {
+        throw normalizeError(err);
+    }
+
+    try {
+        for await (const event of stream) {
+            if (!firstByteAt) firstByteAt = Date.now();
+            chunkCount++;
+
+            if (event.type === 'message_start' && event.message && event.message.usage) {
+                usage = {
+                    prompt_tokens:           event.message.usage.input_tokens  || 0,
+                    completion_tokens:       0,
+                    prompt_cache_hit_tokens: event.message.usage.cache_read_input_tokens || 0,
+                    total_tokens:            event.message.usage.input_tokens  || 0,
+                };
+                continue;
+            }
+
+            if (event.type === 'content_block_start') {
+                const block = event.content_block;
+                if (block && block.type === 'tool_use') {
+                    toolCalls[event.index] = { id: block.id, name: block.name, args: '' };
+                }
+                continue;
+            }
+
+            if (event.type === 'content_block_delta') {
+                const delta = event.delta;
+                if (!delta) continue;
+
+                if (delta.type === 'text_delta' && delta.text) {
+                    callbacks.onDelta && callbacks.onDelta(delta.text);
+                } else if (delta.type === 'thinking_delta' && delta.thinking) {
+                    callbacks.onThinking && callbacks.onThinking(delta.thinking);
+                } else if (delta.type === 'input_json_delta' && delta.partial_json != null) {
+                    const tc = toolCalls[event.index];
+                    if (tc) {
+                        tc.args += delta.partial_json;
+                        callbacks.onToolArgsDelta && callbacks.onToolArgsDelta({
+                            index:     event.index,
+                            id:        tc.id,
+                            name:      tc.name,
+                            deltaArgs: delta.partial_json,
+                            accArgs:   tc.args,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            if (event.type === 'message_delta' && event.usage) {
+                if (!usage) usage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_cache_hit_tokens: 0 };
+                usage.completion_tokens = event.usage.output_tokens || 0;
+                usage.total_tokens      = (usage.prompt_tokens || 0) + usage.completion_tokens;
+            }
+        }
+    } catch (err) {
+        throw normalizeError(err);
+    }
+
+    Logger.info('STREAM_DONE', {
+        elapsed_ms: Date.now() - startedAt,
+        ttfb_ms:    firstByteAt ? firstByteAt - startedAt : null,
+        chunks:     chunkCount,
+        tool_calls: Object.values(toolCalls).length,
+    });
+
+    return { toolCalls: Object.values(toolCalls), usage };
+}
+
+module.exports = { streamChat };

--- a/src/chat/provider.js
+++ b/src/chat/provider.js
@@ -240,8 +240,26 @@ class ChatViewProvider {
                         const https = require('https');
                         const http  = require('http');
                         const base  = resolved.baseUrl.replace(/\/$/, '');
-                        const urlObj = new URL('/chat/completions', base);
-                        const body   = JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 });
+                        const isAnthropic = provider === 'anthropic';
+                        // Anthropic uses a different endpoint and auth scheme from OpenAI-compat providers.
+                        const urlObj  = isAnthropic
+                            ? new URL('/v1/messages', base)
+                            : new URL('/chat/completions', base);
+                        const body    = isAnthropic
+                            ? JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 })
+                            : JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 });
+                        const headers = isAnthropic
+                            ? {
+                                'x-api-key':         testKey || '',
+                                'anthropic-version': '2023-06-01',
+                                'Content-Type':      'application/json',
+                                'Content-Length':    Buffer.byteLength(body),
+                            }
+                            : {
+                                'Authorization':  `Bearer ${testKey || 'ollama'}`,
+                                'Content-Type':   'application/json',
+                                'Content-Length': Buffer.byteLength(body),
+                            };
                         const isHttps = urlObj.protocol === 'https:';
                         const result = await new Promise((resolve) => {
                             const req = (isHttps ? https : http).request({
@@ -249,11 +267,7 @@ class ChatViewProvider {
                                 port:     urlObj.port || (isHttps ? 443 : 80),
                                 path:     urlObj.pathname,
                                 method:   'POST',
-                                headers:  {
-                                    'Authorization': `Bearer ${testKey || 'ollama'}`,
-                                    'Content-Type': 'application/json',
-                                    'Content-Length': Buffer.byteLength(body),
-                                },
+                                headers,
                                 timeout:  10000,
                             }, (res) => {
                                 let raw = '';

--- a/src/chat/provider.js
+++ b/src/chat/provider.js
@@ -35,6 +35,7 @@ const FOLDER_TREE_SKIP = new Set([
     '__pycache__', '.venv', 'venv', '.next', 'coverage', '.turbo',
 ]);
 const { fetchBalance, resolveProviderConfig } = require('../api/adapter');
+const { testConnection: testAnthropicConnection } = require('../api/anthropic-client');
 const { resolveContextRef } = require('./context-refs');
 
 class ChatViewProvider {
@@ -237,55 +238,52 @@ class ChatViewProvider {
                         break;
                     }
                     try {
-                        const https = require('https');
-                        const http  = require('http');
-                        const base  = resolved.baseUrl.replace(/\/$/, '');
-                        const isAnthropic = provider === 'anthropic';
-                        // Anthropic uses a different endpoint and auth scheme from OpenAI-compat providers.
-                        const urlObj  = isAnthropic
-                            ? new URL('/v1/messages', base)
-                            : new URL('/chat/completions', base);
-                        const body    = isAnthropic
-                            ? JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 })
-                            : JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 });
-                        const headers = isAnthropic
-                            ? {
-                                'x-api-key':         testKey || '',
-                                'anthropic-version': '2023-06-01',
-                                'Content-Type':      'application/json',
-                                'Content-Length':    Buffer.byteLength(body),
-                            }
-                            : {
-                                'Authorization':  `Bearer ${testKey || 'ollama'}`,
-                                'Content-Type':   'application/json',
-                                'Content-Length': Buffer.byteLength(body),
-                            };
-                        const isHttps = urlObj.protocol === 'https:';
-                        const result = await new Promise((resolve) => {
-                            const req = (isHttps ? https : http).request({
-                                hostname: urlObj.hostname,
-                                port:     urlObj.port || (isHttps ? 443 : 80),
-                                path:     urlObj.pathname,
-                                method:   'POST',
-                                headers,
-                                timeout:  10000,
-                            }, (res) => {
-                                let raw = '';
-                                res.on('data', c => { raw += c; });
-                                res.on('end', () => {
-                                    if (res.statusCode === 200 || res.statusCode === 201) { resolve({ ok: true }); return; }
-                                    try {
-                                        const d = JSON.parse(raw);
-                                        resolve({ ok: false, error: (d.error && d.error.message) || `HTTP ${res.statusCode}` });
-                                    } catch { resolve({ ok: false, error: `HTTP ${res.statusCode}` }); }
-                                });
-                                res.on('error', e => resolve({ ok: false, error: e.message }));
+                        let result;
+                        if (provider === 'anthropic') {
+                            // Use the native Anthropic SDK for the test — avoids replicating
+                            // the SDK's internal header/URL handling in raw HTTP.
+                            result = await testAnthropicConnection({
+                                apiKey:  testKey,
+                                baseUrl: resolved.baseUrl,
+                                model:   resolved.model,
                             });
-                            req.on('error', e => resolve({ ok: false, error: e.message }));
-                            req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'Timeout' }); });
-                            req.write(body);
-                            req.end();
-                        });
+                        } else {
+                            const https = require('https');
+                            const http  = require('http');
+                            const base  = resolved.baseUrl.replace(/\/$/, '');
+                            const urlObj = new URL('/chat/completions', base);
+                            const body   = JSON.stringify({ model: resolved.model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 });
+                            const isHttps = urlObj.protocol === 'https:';
+                            result = await new Promise((resolve) => {
+                                const req = (isHttps ? https : http).request({
+                                    hostname: urlObj.hostname,
+                                    port:     urlObj.port || (isHttps ? 443 : 80),
+                                    path:     urlObj.pathname,
+                                    method:   'POST',
+                                    headers:  {
+                                        'Authorization':  `Bearer ${testKey || 'ollama'}`,
+                                        'Content-Type':   'application/json',
+                                        'Content-Length': Buffer.byteLength(body),
+                                    },
+                                    timeout:  10000,
+                                }, (res) => {
+                                    let raw = '';
+                                    res.on('data', c => { raw += c; });
+                                    res.on('end', () => {
+                                        if (res.statusCode === 200 || res.statusCode === 201) { resolve({ ok: true }); return; }
+                                        try {
+                                            const d = JSON.parse(raw);
+                                            resolve({ ok: false, error: (d.error && d.error.message) || `HTTP ${res.statusCode}` });
+                                        } catch { resolve({ ok: false, error: `HTTP ${res.statusCode}` }); }
+                                    });
+                                    res.on('error', e => resolve({ ok: false, error: e.message }));
+                                });
+                                req.on('error', e => resolve({ ok: false, error: e.message }));
+                                req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'Timeout' }); });
+                                req.write(body);
+                                req.end();
+                            });
+                        }
                         this._post({ type: 'testApiKeyResult', which, ok: result.ok, latency: Date.now() - t0, error: result.error });
                     } catch (e) {
                         this._post({ type: 'testApiKeyResult', which, ok: false, error: e.message });

--- a/src/webview/html.js
+++ b/src/webview/html.js
@@ -154,6 +154,7 @@ function buildWebviewHtml(webview, extensionUri) {
             <option value="groq">Groq (Llama/Mixtral)</option>
             <option value="ollama">Ollama (local)</option>
             <option value="gemini">Google Gemini</option>
+            <option value="anthropic">Anthropic (Claude)</option>
             <option value="custom">Custom</option>
           </select>
         </div>


### PR DESCRIPTION
<!-- 请按下方模板填写，Copilot / DeepSeek 审核机器人会读取这部分内容 -->

## 变更说明 / Summary
<!-- 这次 PR 做了什么？为什么要做？-->

新增 Anthropic（Claude）作为 AI 提供商。由于 Anthropic API 与 OpenAI 格式不兼容，新增独立的原生 SDK 客户端 src/api/anthropic-client.js，负责将扩展内部的 OpenAI 格式消息转换为 Anthropic 格式，并将响应统一回 OpenAI 格式，使上层代码无需感知提供商差异。
支持 Claude Opus 4.7 / Sonnet 4.6 / Haiku 4.5，支持工具调用、流式输出、多模态图片输入。

## 变更类型 / Type of change
- [ ] Bug 修复
- [ X] 新功能
- [ ] 重构 / 性能优化
- [ ] 文档 / 注释
- [ ] CI / 构建脚本
- [ ] 其他：

## 影响范围 / Affected areas
- [X ] `src/api/**`（DeepSeek 接入）
- [X ] `src/chat/**`（对话核心）
- [ ] `src/tools/**`（工具执行，安全敏感）
- [X ] `src/webview/**`（UI）
- [ ] `src/prompts/**`
- [X ] `package.json` / 依赖
- [ ] CI / `.github/**`
- [ ] 其他：

## 自检 / Checklist
- [X ] 本地手动跑过受影响功能
- [ X] 没有引入新的安全风险（密钥、命令注入、路径穿越）
- [X ] 没有写入个人 / 测试用 API key
- [X ] 修改的 webview 资源遵守了 CSP
- [ ] 必要时已更新 README / Release Notes

## 截图 / 录屏（可选）


## 关联 Issue
Closes #
