### PR TITLE
fix(bg-wait): stop spinner hanging indefinitely after long tasks complete

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -26,3 +26,6 @@ scripts/**
 refine-logs/**
 dangerfile.js
 commitlint.config.mjs
+
+# 测试示例
+demo_test/**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deep-copilot",
   "displayName": "Deep Copilot",
   "description": "Deep Copilot — AI coding agent embedded in VS Code. Powered by DeepSeek V4, with file editing, terminal, search, and plan/todos. Standalone, no backend required.",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "publisher": "ZhouChaunge",
   "icon": "imgs/logo.png",
   "repository": {

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -497,6 +497,35 @@ class AgentLoop {
                         // jobs that ended without firing their SI end event.
                         cleanupStaleJobs();
 
+                        // Skip bg-wait when the model has produced a non-empty
+                        // conclusive reply AND there are no pending job-end events
+                        // to deliver.
+                        //
+                        // Rationale: if a bg job ended *during* the current API
+                        // call, _bgJobEndHandler already queued its event in
+                        // run._pendingBgJobEvents synchronously.  A non-empty
+                        // _pendingBgJobEvents means the model should hear about
+                        // that result → keep the loop alive for ONE more iteration.
+                        //
+                        // Conversely, if _pendingBgJobEvents is empty, the bg job
+                        // is still running (dev server, watcher, etc.).  The model
+                        // already knows — it just told the user about it.  There is
+                        // nothing new to report, so exit the turn immediately rather
+                        // than blocking for up to BG_SNAPSHOT_MS (4 min) or longer.
+                        //
+                        // NOTE: we intentionally do NOT gate on whether the model
+                        // mentioned the jobId by name.  Models routinely include
+                        // "terminal deepseek-job-X is running" in status summaries
+                        // even when the task is fully complete, which would falsely
+                        // bypass this guard if we used a text-match heuristic.
+                        if (assistantText.trim()) {
+                            const _hasPendingEvents = !!(run._pendingBgJobEvents && run._pendingBgJobEvents.length);
+                            if (!_hasPendingEvents) {
+                                Logger.info('BG_WAIT_SKIPPED_MODEL_DONE', { jobs: [...getActiveBgJobs()] });
+                                break;
+                            }
+                        }
+
                         // Honour the turn-level budget: if we have already waited
                         // MAX_BG_WAIT_PER_TURN in this turn (across multiple outer
                         // iterations), give up and exit the loop rather than
@@ -524,10 +553,11 @@ class AgentLoop {
 
                             const ev = await waitForNextBgJobEvent(signal, BG_POLL_MS);
                             if (ev) {
-                                // A job ended — queue event; outer continue will inject
-                                // it as a system-reminder and then call the API once.
-                                if (!run._pendingBgJobEvents) run._pendingBgJobEvents = [];
-                                run._pendingBgJobEvents.push(ev);
+                                // A job ended — _bgJobEndHandler already pushed this
+                                // event to run._pendingBgJobEvents synchronously when
+                                // the SI end event fired.  Do NOT push again here or
+                                // the model will see two identical <system-reminder>
+                                // blocks for the same job completion.
                                 break;
                             }
 

--- a/src/tools/terminal-monitor.js
+++ b/src/tools/terminal-monitor.js
@@ -115,7 +115,19 @@ function cleanupStaleJobs() {
             const list = t ? (_buffers.get(t) || []) : [];
             if (list.length > 0) {
                 const last = list[list.length - 1];
-                if (!last.running) stale = true; // ended without event
+                if (!last.running) {
+                    stale = true; // ended without event
+                } else if (last.startedAt && Date.now() - last.startedAt > 4 * 60 * 60_000) {
+                    // Still flagged as running after 4 h — onDidEndTerminalShellExecution
+                    // was dropped (VS Code shell integration reliability issue).
+                    stale = true;
+                }
+            } else {
+                // Terminal exists but has no buffered executions.  This can happen
+                // when onDidStartTerminalShellExecution never fired (SI race) even
+                // though addActiveBgJob was already called.  We cannot confirm the
+                // job is still running, so treat it as stale to unblock the loop.
+                stale = true;
             }
         }
         if (stale) {


### PR DESCRIPTION
## 问题描述

v0.40.4 中，长任务完成后 spinner 一直显示"distilling"、"crafting"等状态，用户必须手动停止，但实际上没有消耗 token。

**根本原因**：任务完成后 `_activeBgJobs` 中仍然存在一个永远不会退出的后台 job（如 dev server、watcher），agent-loop 进入内层 bg-wait 轮询循环（每 15 秒，最长 4 小时），导致 spinner 挂起。

## 修复内容

### Fix 1 — `agent-loop.js`：重写 bg-wait 跳出条件

**原有逻辑**（有缺陷）：用 `_modelCitesJob` 检测模型回复文本中是否包含 jobId。  
**问题**：模型在状态报告里会自然地提及 jobId（如"终端窗口 `deepseek-job-run-1` 正在运行 `node server.js`"），导致该标志永远为 true，跳出条件失效，仍等待 4 分钟直到 `BG_SNAPSHOT_MS` 触发。

**新逻辑**：仅凭 `_pendingBgJobEvents` 是否为空作为判断：
- 若为空：job 仍在运行，模型已知晓并完成了回复 → 立即退出
- 若非空：job 在本轮 API 调用期间结束，`_bgJobEndHandler` 已同步推入事件 → 继续让模型处理结果

```javascript
if (assistantText.trim()) {
    const _hasPendingEvents = !!(run._pendingBgJobEvents && run._pendingBgJobEvents.length);
    if (!_hasPendingEvents) {
        Logger.info('BG_WAIT_SKIPPED_MODEL_DONE', { jobs: [...getActiveBgJobs()] });
        break;
    }
}
```

### Fix 2 — `agent-loop.js`：去除内层循环重复 push 事件

`waitForNextBgJobEvent` 返回事件时，`_bgJobEndHandler` 已在 SI end 事件触发时同步 push 了相同的事件，导致下一轮注入重复的 `<system-reminder>` 块。已删除内层循环中多余的 `run._pendingBgJobEvents.push(ev)`。

### Fix 3 — `terminal-monitor.js`：修复 `cleanupStaleJobs()` 两个盲区

| 盲区 | 原行为 | 修复后 |
|------|--------|--------|
| 终端存在但 `list.length === 0`（SI 竞态，`onDidStartTerminalShellExecution` 未触发） | 永不清理，一直泄漏到 `_activeBgJobs` | 标记为 stale 并移除 |
| 最后一条执行记录 `running: true` 超过 4 小时 | 永不清理（end 事件被 VS Code 静默丢弃） | 标记为 stale 并移除 |

## 日志佐证

```
[16:15:26] ITER_END iter:16, tool_calls:0, assistant_chars:460  ← 最终回复（含 jobId）
           _modelCitesJob = true → 未能跳出，进入 bg-wait
[16:19:26] BG_SNAPSHOT_INJECTED jobs:["deepseek-job-run-1"], elapsed_s:225  ← 等待 4 分钟
[16:19:31] ITER_END iter:17, tool_calls:0
[16:19:31] BG_WAIT_SKIPPED_MODEL_DONE  ← 旧逻辑在此才生效（Fix 1 新逻辑会在 16:15:26 立即触发）
```

## 版本

`0.40.4` → `0.40.5`