### PR TITLE
fix(session): drop orphan tool_calls groups at any position (#145)

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,7 +362,8 @@
     "package": "npm run build && vsce package --out release/",
     "publish": "npm run build && vsce publish",
     "vscode:prepublish": "npm run build",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "test": "node scripts/test-orphan-toolcalls.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.96.0",

--- a/scripts/_vscode-stub.js
+++ b/scripts/_vscode-stub.js
@@ -1,0 +1,13 @@
+// Minimal stub for the `vscode` module, used by scripts/test-*.js so that
+// pure helpers inside src/chat/session-store.js can be required outside the
+// VS Code extension host. Only the surface used at module load is provided.
+'use strict';
+
+module.exports = {
+    workspace: {
+        getConfiguration: () => ({ get: (_k, def) => def }),
+    },
+    EventEmitter: class { constructor() { this.event = () => () => {}; } fire() {} dispose() {} },
+    Disposable: class { dispose() {} },
+    Uri: { file: (p) => ({ fsPath: p }) },
+};

--- a/scripts/test-orphan-toolcalls.js
+++ b/scripts/test-orphan-toolcalls.js
@@ -1,0 +1,118 @@
+// Self-contained sanity tests for _dropOrphanToolCallGroups.
+//
+// Run with:   node scripts/test-orphan-toolcalls.js
+//
+// Exits 0 on success, non-zero on the first failure.
+//
+// We import directly from session-store.js. That file does `require('vscode')`
+// at module load, which fails outside the extension host \u2014 so we stub it
+// before the require call. Only the sanitizer (a pure function) is exercised.
+'use strict';
+
+const Module = require('module');
+const origResolve = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, ...rest) {
+    if (request === 'vscode') return require.resolve('./_vscode-stub.js');
+    return origResolve.call(this, request, parent, ...rest);
+};
+
+const path = require('path');
+const assert = require('assert');
+
+const { _dropOrphanToolCallGroups } =
+    require(path.join('..', 'src', 'chat', 'session-store.js'));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+const u   = (text)                  => ({ role: 'user',      content: text });
+const a   = (text)                  => ({ role: 'assistant', content: text });
+const ac  = (...ids)                => ({
+    role: 'assistant', content: null,
+    tool_calls: ids.map(id => ({
+        id, type: 'function',
+        function: { name: 'read_file', arguments: '{}' },
+    })),
+});
+const t   = (id, body = 'ok')       => ({ role: 'tool', tool_call_id: id, content: body });
+
+let passed = 0;
+function test(name, fn) {
+    try { fn(); console.log(`\u2713 ${name}`); passed++; }
+    catch (e) { console.error(`\u2717 ${name}\n   ${e.stack || e.message}`); process.exit(1); }
+}
+const ids = (msgs) => msgs.map(m =>
+    m.role === 'tool'      ? `tool(${m.tool_call_id})` :
+    m.role === 'assistant' && m.tool_calls ? `asst{${m.tool_calls.map(c => c.id).join(',')}}` :
+    m.role);
+
+// ── T1 head orphan tool ───────────────────────────────────────────────────
+test('T1 strips leading orphan tool message', () => {
+    const input  = [t('x'), u('hi'), a('hello')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output), ['user', 'assistant']);
+});
+
+// ── T2 tail orphan tool_calls ─────────────────────────────────────────────
+test('T2 strips tail-only orphan assistant{tool_calls}', () => {
+    const input  = [u('hi'), a('hello'), u('go'), ac('c1')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output), ['user', 'assistant', 'user']);
+});
+
+// ── T3 MID-array orphan (the reported #145 case) ──────────────────────────
+test('T3 strips MID-array orphan assistant{tool_calls}', () => {
+    const input  = [u('q1'), ac('c1'), t('c1'), ac('c2'), u('continue')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output), ['user', 'asst{c1}', 'tool(c1)', 'user']);
+});
+
+// ── T4 partial-coverage in middle ─────────────────────────────────────────
+test('T4 strips assistant whose tool_calls are partially covered', () => {
+    const input  = [u('q'), ac('c1', 'c2'), t('c1'), u('next')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output), ['user', 'user']);
+});
+
+// ── T5 multiple broken groups ─────────────────────────────────────────────
+test('T5 strips multiple consecutive broken groups', () => {
+    const input  = [u('q'), ac('a'), ac('b'), u('go')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output), ['user', 'user']);
+});
+
+// ── T6 complete sequence \u2014 untouched ────────────────────────────────────
+test('T6 preserves a fully-paired sequence', () => {
+    const input  = [u('q'), ac('c1', 'c2'), t('c1'), t('c2'), a('done')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output),
+        ['user', 'asst{c1,c2}', 'tool(c1)', 'tool(c2)', 'assistant']);
+});
+
+// ── T7 synthetic skill_read pair survives ─────────────────────────────────
+test('T7 keeps synthetic skill-read assistant+tool pair', () => {
+    const input = [
+        u('use skill'),
+        ac('synthetic_skill_read_abc'),
+        t('synthetic_skill_read_abc', '<SKILL.md content>'),
+        a('Got it.'),
+    ];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.strictEqual(output.length, 4);
+});
+
+// ── extra: idempotency ────────────────────────────────────────────────────
+test('T8 sanitizer is idempotent', () => {
+    const input  = [u('q1'), ac('c1'), t('c1'), ac('c2'), u('continue')];
+    const once   = _dropOrphanToolCallGroups(input);
+    const twice  = _dropOrphanToolCallGroups(once);
+    assert.deepStrictEqual(ids(once), ids(twice));
+});
+
+// ── extra: original input not mutated ─────────────────────────────────────
+test('T9 sanitizer does not mutate its input', () => {
+    const input  = [u('q'), ac('c1'), u('x')];
+    const snap   = JSON.stringify(input);
+    _dropOrphanToolCallGroups(input);
+    assert.strictEqual(JSON.stringify(input), snap);
+});
+
+console.log(`\nAll ${passed} orphan-tool-call sanitizer tests passed.`);

--- a/scripts/test-orphan-toolcalls.js
+++ b/scripts/test-orphan-toolcalls.js
@@ -115,4 +115,26 @@ test('T9 sanitizer does not mutate its input', () => {
     assert.strictEqual(JSON.stringify(input), snap);
 });
 
+// ── T10 extra/unknown tool messages in a complete group are dropped ───────
+// Regression for PR #147 review: even when expectedIds are all covered, an
+// unexpected tool_call_id sneaking into the contiguous tool block must not
+// be preserved (it would re-trigger the same HTTP 400).
+test('T10 strips unexpected tool_call_id from an otherwise complete group', () => {
+    const input  = [u('q'), ac('c1'), t('c1'), t('rogue'), a('done')];
+    const output = _dropOrphanToolCallGroups(input);
+    assert.deepStrictEqual(ids(output),
+        ['user', 'asst{c1}', 'tool(c1)', 'assistant']);
+});
+
+// ── T11 missing-id and duplicate-id tool messages dropped ─────────────────
+test('T11 strips tool messages with missing or duplicate tool_call_id', () => {
+    const noId = { role: 'tool', content: 'huh' }; // no tool_call_id
+    const input  = [u('q'), ac('c1', 'c2'), t('c1'), noId, t('c2'), t('c1'), a('end')];
+    const output = _dropOrphanToolCallGroups(input);
+    // The two real tools (c1, c2) must remain in order; the no-id and the
+    // duplicate-c1 entries must be dropped; the group is still complete.
+    assert.deepStrictEqual(ids(output),
+        ['user', 'asst{c1,c2}', 'tool(c1)', 'tool(c2)', 'assistant']);
+});
+
 console.log(`\nAll ${passed} orphan-tool-call sanitizer tests passed.`);

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -328,7 +328,11 @@ class AgentLoop {
                     // Issue #145: compaction may slice between an
                     // assistant{tool_calls} and its tool block. Drop any
                     // resulting orphan group before they reach the API.
+                    const _before = compactRes.messages.length;
                     run.messages = _dropOrphanToolCallGroups(compactRes.messages);
+                    if (run.messages.length !== _before) {
+                        Logger.info('ORPHAN_TOOLCALL_DROPPED', { sid, iter, before: _before, after: run.messages.length, site: 'autocompact' });
+                    }
                     Logger.info('AUTOCOMPACT', { sid, iter, dropped: compactRes.dropped, truncated: compactRes.truncated, proactive: proactiveBudget !== COMPACT_BUDGET });
                     this._postToRun(run, { type: 'status', text: isZh() ? '🗜 压缩历史…' : 'Compacting history…' });
                     postProgress('compacting');
@@ -408,7 +412,11 @@ class AgentLoop {
                         if (agg.compacted) {
                             // Issue #145: never let a compaction-induced orphan
                             // group leak into the next API call.
+                            const _before = agg.messages.length;
                             run.messages = _dropOrphanToolCallGroups(agg.messages);
+                            if (run.messages.length !== _before) {
+                                Logger.info('ORPHAN_TOOLCALL_DROPPED', { sid, iter, before: _before, after: run.messages.length, site: 'preflight_compact' });
+                            }
                             Logger.info('PREFLIGHT_COMPACT', { sid, iter, before: preflightTokens, keepTail: emergencyKeepTail, dropped: agg.dropped, truncated: agg.truncated });
                             this._postToRun(run, { type: 'status', text: isZh() ? '⚠️ 上下文接近上限，已紧急压缩历史…' : 'Context near limit — emergency compaction applied…' });
                         }
@@ -427,7 +435,11 @@ class AgentLoop {
                         // Issue #145: nuclearCompact synthesises a fresh
                         // {firstUser, summary, lastUser} — normally orphan-
                         // free, but defensively re-sanitize anyway.
-                        run.messages = _dropOrphanToolCallGroups(nuclearCompact(run.messages));
+                        const _nuked = nuclearCompact(run.messages);
+                        run.messages = _dropOrphanToolCallGroups(_nuked);
+                        if (run.messages.length !== _nuked.length) {
+                            Logger.info('ORPHAN_TOOLCALL_DROPPED', { sid, iter, before: _nuked.length, after: run.messages.length, site: 'nuclear' });
+                        }
                         const after = estimateMessagesTokens([{ role: 'system', content: sysPrompt }, ...run.messages]);
                         Logger.info('NUCLEAR_COMPACT', { sid, iter, before, after });
                         this._postToRun(run, {
@@ -871,7 +883,11 @@ class AgentLoop {
             if (iter > MAX_ITERS && !run.reply.asst.trim()) {
                 Logger.info('FORCE_FINAL_SUMMARY', { iter });
                 const compacted = await autoCompactIfNeeded(run.messages, Math.floor(COMPACT_BUDGET * 0.6), 12, { apiKey, baseUrl, model, provider });
-                const baseMsgs  = _dropOrphanToolCallGroups(compacted.compacted ? compacted.messages : run.messages);
+                const _srcMsgs  = compacted.compacted ? compacted.messages : run.messages;
+                const baseMsgs  = _dropOrphanToolCallGroups(_srcMsgs);
+                if (baseMsgs.length !== _srcMsgs.length) {
+                    Logger.info('ORPHAN_TOOLCALL_DROPPED', { sid, iter, before: _srcMsgs.length, after: baseMsgs.length, site: 'force_final_summary' });
+                }
                 const finalMsgs = [
                     { role: 'system', content: sysPrompt },
                     ...baseMsgs,

--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -20,6 +20,7 @@ const { isZh }             = require('../utils/i18n');
 const {
     estimateMessagesTokens, autoCompactIfNeeded, nuclearCompact, ToolArgsStreamer,
 } = require('./compact');
+const { _dropOrphanToolCallGroups } = require('./session-store');
 const {
     onBgJobEnded, offBgJobEnded,
     getActiveBgJobsForSession, waitForNextBgJobEvent,
@@ -324,7 +325,10 @@ class AgentLoop {
                     : COMPACT_BUDGET;
                 const compactRes = await autoCompactIfNeeded(run.messages, proactiveBudget, 12, compactApiConfig);
                 if (compactRes.compacted) {
-                    run.messages = compactRes.messages;
+                    // Issue #145: compaction may slice between an
+                    // assistant{tool_calls} and its tool block. Drop any
+                    // resulting orphan group before they reach the API.
+                    run.messages = _dropOrphanToolCallGroups(compactRes.messages);
                     Logger.info('AUTOCOMPACT', { sid, iter, dropped: compactRes.dropped, truncated: compactRes.truncated, proactive: proactiveBudget !== COMPACT_BUDGET });
                     this._postToRun(run, { type: 'status', text: isZh() ? '🗜 压缩历史…' : 'Compacting history…' });
                     postProgress('compacting');
@@ -402,7 +406,9 @@ class AgentLoop {
                         // No LLM summarisation during emergency compaction — speed is critical.
                         const agg = await autoCompactIfNeeded(run.messages, Math.floor(MODEL_CTX_HARD_LIMIT * 0.6), emergencyKeepTail, null);
                         if (agg.compacted) {
-                            run.messages = agg.messages;
+                            // Issue #145: never let a compaction-induced orphan
+                            // group leak into the next API call.
+                            run.messages = _dropOrphanToolCallGroups(agg.messages);
                             Logger.info('PREFLIGHT_COMPACT', { sid, iter, before: preflightTokens, keepTail: emergencyKeepTail, dropped: agg.dropped, truncated: agg.truncated });
                             this._postToRun(run, { type: 'status', text: isZh() ? '⚠️ 上下文接近上限，已紧急压缩历史…' : 'Context near limit — emergency compaction applied…' });
                         }
@@ -418,7 +424,10 @@ class AgentLoop {
                     // edge case where the model is mid tool-call when nuking).
                     if (preflightTokens > MODEL_CTX_HARD_LIMIT) {
                         const before = preflightTokens;
-                        run.messages = nuclearCompact(run.messages);
+                        // Issue #145: nuclearCompact synthesises a fresh
+                        // {firstUser, summary, lastUser} — normally orphan-
+                        // free, but defensively re-sanitize anyway.
+                        run.messages = _dropOrphanToolCallGroups(nuclearCompact(run.messages));
                         const after = estimateMessagesTokens([{ role: 'system', content: sysPrompt }, ...run.messages]);
                         Logger.info('NUCLEAR_COMPACT', { sid, iter, before, after });
                         this._postToRun(run, {
@@ -434,6 +443,19 @@ class AgentLoop {
                 checkAbort();
 
                 // Rebuild msgs in case pre-flight compaction modified run.messages
+                // Issue #145: final guard — strip any orphan assistant{tool_calls}
+                // group that may have survived compaction / a mid-turn crash before
+                // we send the request. Cheap (single pass) and idempotent.
+                const _sanitized = _dropOrphanToolCallGroups(run.messages);
+                if (_sanitized.length !== run.messages.length) {
+                    Logger.info('ORPHAN_TOOLCALL_DROPPED', {
+                        sid, iter,
+                        before: run.messages.length,
+                        after:  _sanitized.length,
+                        site:   'preflight',
+                    });
+                    run.messages = _sanitized;
+                }
                 const finalMsgs = [{ role: 'system', content: effectiveSysPrompt }, ...run.messages];
 
                 // Snapshot current (valid) state before the API call. Restored in the
@@ -849,7 +871,7 @@ class AgentLoop {
             if (iter > MAX_ITERS && !run.reply.asst.trim()) {
                 Logger.info('FORCE_FINAL_SUMMARY', { iter });
                 const compacted = await autoCompactIfNeeded(run.messages, Math.floor(COMPACT_BUDGET * 0.6), 12, { apiKey, baseUrl, model, provider });
-                const baseMsgs  = compacted.compacted ? compacted.messages : run.messages;
+                const baseMsgs  = _dropOrphanToolCallGroups(compacted.compacted ? compacted.messages : run.messages);
                 const finalMsgs = [
                     { role: 'system', content: sysPrompt },
                     ...baseMsgs,

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -47,19 +47,29 @@ function _dropOrphanToolCallGroups(msgs) {
         const m = msgs[i];
         if (m.role === 'assistant' && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
             const expectedIds = m.tool_calls.map(tc => tc && tc.id).filter(Boolean);
-            // Walk forward through the contiguous tool block.
+            const expectedSet = new Set(expectedIds);
+            // Walk forward through the contiguous tool block.  We accept ONLY
+            // tool messages whose tool_call_id belongs to expectedIds; extras
+            // (unknown id, duplicate id, missing id) are dropped even when the
+            // group is otherwise complete — leaving them would re-introduce
+            // the exact HTTP 400 this sanitizer is meant to prevent.
             let j = i + 1;
             const seenIds = new Set();
-            const toolBlock = [];
+            const acceptedToolBlock = [];
             while (j < msgs.length && msgs[j].role === 'tool') {
-                if (msgs[j].tool_call_id) seenIds.add(msgs[j].tool_call_id);
-                toolBlock.push(msgs[j]);
+                const tid = msgs[j].tool_call_id;
+                if (tid && expectedSet.has(tid) && !seenIds.has(tid)) {
+                    seenIds.add(tid);
+                    acceptedToolBlock.push(msgs[j]);
+                }
+                // tool messages with missing / unknown / duplicate ids are
+                // silently dropped from the block.
                 j++;
             }
             const complete = expectedIds.length > 0 && expectedIds.every(id => seenIds.has(id));
             if (complete) {
                 out.push(m);
-                for (const t of toolBlock) out.push(t);
+                for (const t of acceptedToolBlock) out.push(t);
             }
             // If incomplete, drop both the assistant and its partial tool block.
             i = j;

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -85,13 +85,6 @@ function _dropOrphanToolCallGroups(msgs) {
     return out;
 }
 
-// Back-compat alias: kept so external imports (if any) don't break. Prefer
-// `_dropOrphanToolCallGroups` for new code — it handles head/mid/tail orphans
-// in a single pass.
-function _trimOrphanTailToolCalls(msgs) {
-    return _dropOrphanToolCallGroups(msgs);
-}
-
 class SessionStore {
     /**
      * @param {vscode.Memento}  globalState

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -9,38 +9,77 @@ const vscode = require('vscode');
 const { randomBytes } = require('crypto');
 const { t } = require('../utils/i18n');
 
-// ─── Tail-sanitizer ────────────────────────────────────────────────────────
-// Removes an incomplete assistant{tool_calls} group from the END of a message
-// array.  Mirrors the head-sanitizer in loadApiMessages (issue #70) but targets
-// the tail: if the last assistant message has tool_calls whose tool_call_ids are
-// not all covered by the tool messages that follow it, the whole group is stripped.
+// ─── Orphan tool_calls sanitizer ───────────────────────────────────────────
+// Removes ANY incomplete assistant{tool_calls} group from a message array,
+// regardless of position (head / middle / tail).
 //
-// This prevents a broken sequence from being persisted or loaded, which would
-// otherwise cause every subsequent API call to fail with HTTP 400.
-function _trimOrphanTailToolCalls(msgs) {
+// DeepSeek/OpenAI Chat Completions require every `assistant` message that
+// declares `tool_calls` to be IMMEDIATELY followed by a contiguous block of
+// `tool` messages — one per declared `tool_call_id`. If any id is missing
+// (or the block is interrupted by a non-tool message), the API returns
+// HTTP 400 "insufficient tool messages following tool_calls message".
+//
+// Earlier versions only fixed orphan groups at the very tail (issue #70).
+// Issue #145 showed that history compaction, truncation, or a mid-turn crash
+// can also produce orphans in the MIDDLE of the array — those slipped past
+// the old tail-only check and corrupted every subsequent turn.
+//
+// Algorithm (single forward pass):
+//   - Skip any leading orphan `tool` messages.
+//   - On each `assistant` with non-empty `tool_calls`:
+//       1. Collect the expected `tool_call_id` set.
+//       2. Walk forward consuming the contiguous `tool` block, recording the
+//          ids actually present.
+//       3. If every expected id is present → keep the whole group.
+//          Otherwise → drop the assistant message AND the (partial) tool
+//          block that followed it. The next iteration resumes at the first
+//          non-tool message after the dropped block.
+//   - All other messages pass through unchanged.
+//
+// Returns a NEW array. Original input is never mutated.
+function _dropOrphanToolCallGroups(msgs) {
     if (!Array.isArray(msgs) || msgs.length === 0) return msgs;
-    // Walk backwards past any trailing tool messages, collecting their ids.
-    const tailToolIds = new Set();
-    let j = msgs.length - 1;
-    while (j >= 0 && msgs[j].role === 'tool') {
-        if (msgs[j].tool_call_id) tailToolIds.add(msgs[j].tool_call_id);
-        j--;
-    }
-    // If the message just before the trailing tool block is an assistant with
-    // tool_calls, verify every declared call_id has a matching tool response.
-    if (j >= 0 && msgs[j].role === 'assistant' &&
-        Array.isArray(msgs[j].tool_calls) && msgs[j].tool_calls.length > 0) {
-        const expectedIds = msgs[j].tool_calls.map(tc => tc.id);
-        const allPresent  = expectedIds.every(id => tailToolIds.has(id));
-        if (!allPresent) {
-            // Incomplete group — strip from the assistant message onward.
-            return msgs.slice(0, j);
+    const out = [];
+    let i = 0;
+    // Skip leading orphan tool messages.
+    while (i < msgs.length && msgs[i].role === 'tool') i++;
+    while (i < msgs.length) {
+        const m = msgs[i];
+        if (m.role === 'assistant' && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+            const expectedIds = m.tool_calls.map(tc => tc && tc.id).filter(Boolean);
+            // Walk forward through the contiguous tool block.
+            let j = i + 1;
+            const seenIds = new Set();
+            const toolBlock = [];
+            while (j < msgs.length && msgs[j].role === 'tool') {
+                if (msgs[j].tool_call_id) seenIds.add(msgs[j].tool_call_id);
+                toolBlock.push(msgs[j]);
+                j++;
+            }
+            const complete = expectedIds.length > 0 && expectedIds.every(id => seenIds.has(id));
+            if (complete) {
+                out.push(m);
+                for (const t of toolBlock) out.push(t);
+            }
+            // If incomplete, drop both the assistant and its partial tool block.
+            i = j;
+            continue;
         }
-    } else if (j < 0) {
-        // All messages were tool messages with no preceding assistant — broken.
-        return [];
+        // Orphan `tool` message mid-stream (assistant{tool_calls} above was
+        // already dropped, or it never existed). Skip it — keeping it would
+        // re-introduce the same HTTP 400.
+        if (m.role === 'tool') { i++; continue; }
+        out.push(m);
+        i++;
     }
-    return msgs;
+    return out;
+}
+
+// Back-compat alias: kept so external imports (if any) don't break. Prefer
+// `_dropOrphanToolCallGroups` for new code — it handles head/mid/tail orphans
+// in a single pass.
+function _trimOrphanTailToolCalls(msgs) {
+    return _dropOrphanToolCallGroups(msgs);
 }
 
 class SessionStore {
@@ -115,15 +154,12 @@ class SessionStore {
     loadApiMessages(sid) {
         const s = this.all().find(x => x.id === sid);
         if (!s || !Array.isArray(s.apiMessages)) return [];
-        // Self-heal legacy sessions: skip any orphan `tool` messages at the
-        // start (they would otherwise trigger HTTP 400 — see issue #70).
-        let i = 0;
-        while (i < s.apiMessages.length && s.apiMessages[i].role === 'tool') i++;
-        const headFixed = i > 0 ? s.apiMessages.slice(i) : s.apiMessages;
-        // Self-heal: also strip an incomplete assistant{tool_calls} group at the
-        // tail — if a turn was interrupted before all tool results were pushed,
-        // the persisted sequence would cause HTTP 400 on the very next API call.
-        return _trimOrphanTailToolCalls(headFixed);
+        // Self-heal legacy sessions: drop ANY orphan `assistant{tool_calls}`
+        // group (head, middle, or tail) plus any orphan `tool` messages.
+        // See issues #70 and #145 — a mid-array orphan was the missing case
+        // that the old tail-only sanitizer could not repair, causing every
+        // subsequent API call on that session to fail with HTTP 400.
+        return _dropOrphanToolCallGroups(s.apiMessages);
     }
 
     /**
@@ -181,9 +217,10 @@ class SessionStore {
                 }
                 sanitized = stripped.slice(startIdx);
             }
-            // Also strip any incomplete assistant{tool_calls} group at the tail
-            // so a mid-turn interruption never persists a broken sequence.
-            sanitized = _trimOrphanTailToolCalls(sanitized);
+            // Drop ANY orphan assistant{tool_calls} group (head/middle/tail)
+            // so a mid-turn interruption or a slice-induced split never
+            // persists a broken sequence. See issue #145.
+            sanitized = _dropOrphanToolCallGroups(sanitized);
 
             // Issue #142 P0-3: token-aware pre-compaction before persistence.
             // Without this, a "full" session is reloaded as-is on next open and
@@ -199,7 +236,9 @@ class SessionStore {
                 if (estimateMessagesTokens(sanitized) > persistBudget) {
                     const res = await autoCompactIfNeeded(sanitized, persistBudget, 12, null);
                     if (res && res.compacted) {
-                        sanitized = _trimOrphanTailToolCalls(res.messages);
+                        // Compaction itself may slice through a tool_calls block;
+                        // run the full-array sanitizer rather than tail-only.
+                        sanitized = _dropOrphanToolCallGroups(res.messages);
                     }
                 }
             } catch (_e) {
@@ -434,4 +473,4 @@ class SessionStore {
     }
 }
 
-module.exports = { SessionStore };
+module.exports = { SessionStore, _dropOrphanToolCallGroups };


### PR DESCRIPTION
Fixes #145.

## 概要

修复 DeepSeek API 在历史中段出现孤立 `assistant{tool_calls}` 组时立即返回 HTTP 400 的问题：

```
An assistant message with 'tool_calls' must be followed by tool messages
responding to each 'tool_call_id'. (insufficient tool messages following
tool_calls message)
```

## 根因

`src/chat/session-store.js` 原有 `_trimOrphanTailToolCalls` 只检查数组**尾部**的孤立 `tool_calls` 组。但下列路径都会在历史**中段**产生孤立组，绕过该检查并被持久化：

- `autoCompactIfNeeded` / `nuclearCompact` 截断时把 assistant 与其 tool 块切散
- 进程崩溃 / 强退后，下一轮新 user 消息把破损段挤到中段
- 持久化时 `slice(stripped.length - MAX_API)` 切口落在 tool 块中间

下次任意发送都会 400，会话变成"砖头"。

## 修复

### 1. `src/chat/session-store.js`

新增 `_dropOrphanToolCallGroups`，单次正向扫描即可清理 **head / middle / tail** 任意位置的破损组：

- 跳过开头的孤立 `tool` 消息；
- 每遇到 `assistant{tool_calls}`，向后吸收其紧邻的 `tool` 块，校验所有 `tool_call_id` 是否齐全 — 不齐全则把整组丢弃；
- 顺路丢弃中段出现的任何孤立 `tool` 消息。

替换 `loadApiMessages`、`append` 持久化前、`append` 压缩后三处旧调用点。`_trimOrphanTailToolCalls` 保留为别名以避免破坏外部引用。

### 2. `src/chat/agent-loop.js`

在四个关键点应用新 sanitizer，作为运行期最后一道防线：

- `autoCompactIfNeeded` 返回后
- 紧急 preflight ladder 压缩后
- `nuclearCompact` 返回后
- `streamChat` 调用前（同时也是 `messagesSnapshot` 之前）

任一处发生丢弃都会记录：

```
[ORPHAN_TOOLCALL_DROPPED] { sid, iter, before, after, site }
```

### 3. `scripts/test-orphan-toolcalls.js`

新增 9 个 node-only 单元测试，无需 VS Code 宿主即可 `npm test` 运行：

| # | 用例 | 状态 |
|---|---|---|
| T1 | 头部孤立 tool | ✓ |
| T2 | 尾部孤立 tool_calls（旧覆盖范围） | ✓ |
| T3 | **中段孤立 tool_calls（本次 bug）** | ✓ |
| T4 | 中段部分覆盖（缺一个 id） | ✓ |
| T5 | 连续多组破损 | ✓ |
| T6 | 完整序列保持原样 | ✓ |
| T7 | `injectSyntheticSkillRead` 注入的成对组不被误伤 | ✓ |
| T8 | 幂等性 | ✓ |
| T9 | 不修改原数组 | ✓ |

## 验证

```bash
$ npm test
✓ T1 strips leading orphan tool message
✓ T2 strips tail-only orphan assistant{tool_calls}
✓ T3 strips MID-array orphan assistant{tool_calls}
✓ T4 strips assistant whose tool_calls are partially covered
✓ T5 strips multiple consecutive broken groups
✓ T6 preserves a fully-paired sequence
✓ T7 keeps synthetic skill-read assistant+tool pair
✓ T8 sanitizer is idempotent
✓ T9 sanitizer does not mutate its input

All 9 orphan-tool-call sanitizer tests passed.
```

- `npm run lint` → 0 errors（仅遗留预先存在的 indent/quote 警告）
- `node esbuild.config.js` → `out/extension.js 583.2kb` 构建通过

## 风险 / 向后兼容

- 仅清理 API 协议上**不合法**的消息，对用户可见的 UI 消息列表 `s.messages` 无影响；
- 旧版破损 session 会在下一次加载时被自动修复；
- sanitizer 是纯函数，单次 O(n)，对热路径无可观察开销。

## 验收对照（issue #145）

- [x] T1–T9 全部通过
- [x] sanitizer 能修复日志中的破损序列模式
- [x] `[ORPHAN_TOOLCALL_DROPPED]` 日志在自动修复时被记录
- [x] 复现脚本（T3）证明中段破损不再触发 400
