### PR TITLE
fix: preserve reasoning_content across session reloads; fix skill_invoke injection order

### DIFF
--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -883,6 +883,18 @@ class AgentLoop {
                     }
                 } // end Phase 3 for-loop
 
+                // Phase 3b: flush any skill_invoke-deferred synthetic read_file pairs.
+                // skill_invoke no longer injects inline (doing so mid-block broke the
+                // contiguous tool-call sequence and caused _dropOrphanToolCallGroups to
+                // drop the real assistant message + its reasoning_content).  Instead it
+                // queues the injection here, after all real tool results are in place.
+                if (Array.isArray(run._pendingSkillInjections) && run._pendingSkillInjections.length) {
+                    for (const { name, body, skillPath } of run._pendingSkillInjections) {
+                        injectSyntheticSkillRead(run.messages, name, body, skillPath);
+                    }
+                    run._pendingSkillInjections = [];
+                }
+
                 // Append deferred hints after all tool messages — preserves the required
                 // API sequence: assistant{tool_calls} → N×tool → (optional) user hints.
                 for (const hint of pendingHints) run.messages.push(hint);

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -204,21 +204,24 @@ class SessionStore {
 
         if (apiMessages !== undefined) {
             const MAX_API = 200;
-            const stripped = Array.isArray(apiMessages) ? apiMessages.map(m => {
-                if (!m.reasoning_content) return m;
-                const { reasoning_content, ...rest } = m; // eslint-disable-line no-unused-vars
-                return rest;
-            }) : [];
+            // reasoning_content is intentionally kept here.  Stripping it at
+            // persist time caused HTTP 400 ("reasoning_content must be passed
+            // back") when a session was reloaded after a VS Code restart —
+            // the in-memory run was gone, messages came back from storage
+            // without the field, and DeepSeek rejected the next turn.
+            // sanitizeMessages() in adapter.js already handles per-model
+            // stripping at API-call time, so we don't need to do it here.
+            const messagesToPersist = Array.isArray(apiMessages) ? [...apiMessages] : [];
             // Truncate to the last MAX_API messages, but never start with an
             // orphan `tool` message — DeepSeek requires every tool message to
             // follow its assistant{tool_calls}. See issue #70.
-            let sanitized = stripped;
-            if (stripped.length > MAX_API) {
-                let startIdx = stripped.length - MAX_API;
-                while (startIdx < stripped.length && stripped[startIdx].role === 'tool') {
+            let sanitized = messagesToPersist;
+            if (messagesToPersist.length > MAX_API) {
+                let startIdx = messagesToPersist.length - MAX_API;
+                while (startIdx < messagesToPersist.length && messagesToPersist[startIdx].role === 'tool') {
                     startIdx++;
                 }
-                sanitized = stripped.slice(startIdx);
+                sanitized = messagesToPersist.slice(startIdx);
             }
             // Drop ANY orphan assistant{tool_calls} group (head/middle/tail)
             // so a mid-turn interruption or a slice-induced split never

--- a/src/tools/skill-tools.js
+++ b/src/tools/skill-tools.js
@@ -14,11 +14,6 @@ const path = require('path');
 
 const { discoverSkills, DEEPCOPILOT_SKILLS_DIR } = require('../skills');
 const { wsRoot } = require('../utils/paths');
-// Lazy-require to avoid module-load cycles via tool-executor.js.
-function _injectSkill(messages, name, body, skillPath) {
-    const { injectSyntheticSkillRead } = require('../chat/agent-loop');
-    return injectSyntheticSkillRead(messages, name, body, skillPath);
-}
 
 // ─── skill_invoke ────────────────────────────────────────────────────────────
 
@@ -54,7 +49,17 @@ function skillInvoke(args, run) {
     // Pass the real on-disk path so the synthetic read_file call reflects the
     // actual source location (may be ~/.claude/skills/ or ~/.copilot/skills/).
     const realSkillPath = path.join(s.dir, s.name, 'SKILL.md');
-    _injectSkill(run.messages, s.name, body, realSkillPath);
+
+    // Defer the synthetic read_file pair injection to AFTER all real tool
+    // results for the current assistant turn have been pushed.  Injecting
+    // inline here (during Phase 2 execution) would insert the synthetic
+    // assistant{read_file}+tool pair between the real assistant message and
+    // its pending tool results, breaking the contiguous block requirement and
+    // causing _dropOrphanToolCallGroups to discard the original assistant
+    // message — along with any reasoning_content it carried.
+    if (!Array.isArray(run._pendingSkillInjections)) run._pendingSkillInjections = [];
+    run._pendingSkillInjections.push({ name: s.name, body, skillPath: realSkillPath });
+
     return `Loaded skill "${s.name}" (${s.source}/${s.trust}). The SOP is now in your context as a synthetic read_file result — follow it to complete the user's task.`;
 }
 


### PR DESCRIPTION
Fixes #159

## 变更摘要 / Summary of Changes

### 主修复 / Primary Fix — `src/chat/session-store.js`

移除了对 `reasoning_content` 的**无条件**持久化剥除逻辑。  
Removes the unconditional stripping of `reasoning_content` during message persistence.

**原因 / Why：**  
`session-store.js` 在持久化时剥除 `reasoning_content`，导致 VS Code 重启后通过 `loadApiMessages()` 恢复的历史消息缺少该字段。DeepSeek API 在 thinking 模式下要求每轮都回传 `reasoning_content`，缺失则返回 HTTP 400。  
`session-store.js` was stripping `reasoning_content` at persist time, so after a VS Code restart, `loadApiMessages()` returned history without the field. DeepSeek requires `reasoning_content` to be passed back every turn in thinking mode, returning HTTP 400 when absent.

`sanitizeMessages()` in `adapter.js` already handles per-model stripping at API-call time (exempting `capabilities.reasoning: true` models), so persistence no longer needs to do it.

---

### 次修复 / Secondary Fix — `src/tools/skill-tools.js` + `src/chat/agent-loop.js`

`skillInvoke()` 不再在 Phase 2 执行期间立即调用 `injectSyntheticSkillRead()`，改为将注入数据写入 `run._pendingSkillInjections`，由 agent-loop 在 Phase 3 所有真实 tool 结果推入之后（新增 Phase 3b）统一处理。  
`skillInvoke()` no longer calls `injectSyntheticSkillRead()` inline during Phase 2 execution. Instead it queues the injection in `run._pendingSkillInjections`; agent-loop flushes the queue in a new Phase 3b, after all real tool results have been pushed.

**原因 / Why：**  
内联注入会在 `assistant{reasoning_content, tool_calls:[skill_invoke]}` 和其 `tool` 结果之间插入一对合成消息，打断 tool-call 连续块，导致 `_dropOrphanToolCallGroups()` 将原始 assistant 消息（含 `reasoning_content`）整体丢弃。  
Inline injection inserted a synthetic `assistant{read_file}` + `tool` pair between the real assistant message and its tool result, breaking the contiguous block. `_dropOrphanToolCallGroups()` then discarded the entire original assistant message along with its `reasoning_content`.

**消息序列对比 / Message sequence before → after：**

```
Before:
  assistant{rc, tool_calls:[skill_invoke]}   ← orphaned, DROPPED by sanitizer
  assistant{tool_calls:[read_file]}          ← synthetic (inserted mid-block)
  tool{read_file}
  tool{skill_invoke}                         ← orphaned, DROPPED

After:
  assistant{rc, tool_calls:[skill_invoke]}   ← kept ✓
  tool{skill_invoke}                         ← kept ✓
  assistant{tool_calls:[read_file]}          ← synthetic (appended after)
  tool{read_file}                            ← kept ✓
```

---

## 涉及文件 / Files Changed

| File | Change |
|------|--------|
| `src/chat/session-store.js` | Remove `reasoning_content` strip on persist |
| `src/tools/skill-tools.js` | Queue injection instead of injecting inline; remove dead `_injectSkill` helper |
| `src/chat/agent-loop.js` | Add Phase 3b to flush `_pendingSkillInjections` after all tool results |