### PR TITLE
fix(webview): write_file streaming state corruption + tool-row UX polish (closes #162)

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -202,9 +202,11 @@ body.narrow #main{padding-left:12px;padding-right:12px}
 .tl.run .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:#e8b86d;margin-right:4px;vertical-align:middle;animation:thpulse 1.4s ease-out infinite}
 /* Issue #162: completion indicator lives on the row itself, not just on .tl-stream,
    so completed tool rows show the green dot even when the live preview path never ran
-   (non-streaming providers, session replay, content-before-path field order, etc.). */
+   (non-streaming providers, session replay, content-before-path field order, etc.).
+   Failures intentionally get no coloured dot — see the "Suppress red failed styling"
+   block near the end of this file: tool errors are kept neutral so they blend with
+   normal output instead of alarming the user. */
 .tl.ok  .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:#7bc47f;margin-right:4px;vertical-align:middle}
-.tl.err .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--vscode-errorForeground);margin-right:4px;vertical-align:middle}
 .tl.err .tl-res{color:var(--vscode-errorForeground);opacity:.9}
 .tl .tl-exp{flex-shrink:0;font-size:10px;font-family:"codicon";opacity:0;transition:opacity .12s,transform .15s;width:12px;color:var(--vscode-descriptionForeground);margin-left:2px;pointer-events:none}
 .tl.has-detail{cursor:pointer}
@@ -706,7 +708,9 @@ body.vscode-light .settings-test-result.ok{color:#267f26}
 .tl.err   .ico    { color: var(--vscode-descriptionForeground) !important; opacity: .7 !important; }
 .tl.err   .tl-res { color: var(--vscode-descriptionForeground) !important; opacity: .55 !important; }
 .tl-stream.done.err            { border-left-color: var(--vscode-panel-border) !important; }
-.tl-stream.done.err::before    { content: "done" !important; color: var(--vscode-descriptionForeground) !important; opacity: .55 !important; }
+/* Failed streams: clear the "failed" badge entirely rather than claim "done" —
+   we want failures to blend in, not to misrepresent themselves as successful. */
+.tl-stream.done.err::before    { content: "" !important; }
 
 /* ── Status dot: orange-pulsing while running → static green on success ──
    The orange running dot is defined inline on `.tool.run .h .nm::after`

--- a/media/chat.css
+++ b/media/chat.css
@@ -200,6 +200,11 @@ body.narrow #main{padding-left:12px;padding-right:12px}
 .tl-list .tl .tl-prose code{background:var(--vscode-badge-background,rgba(90,93,94,.3));color:var(--vscode-badge-foreground,inherit);border-radius:3px;padding:0 4px;opacity:1}
 .tl .tl-res{flex-shrink:0;font-size:10px;opacity:.55;margin-left:4px}
 .tl.run .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:#e8b86d;margin-right:4px;vertical-align:middle;animation:thpulse 1.4s ease-out infinite}
+/* Issue #162: completion indicator lives on the row itself, not just on .tl-stream,
+   so completed tool rows show the green dot even when the live preview path never ran
+   (non-streaming providers, session replay, content-before-path field order, etc.). */
+.tl.ok  .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:#7bc47f;margin-right:4px;vertical-align:middle}
+.tl.err .tl-res::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--vscode-errorForeground);margin-right:4px;vertical-align:middle}
 .tl.err .tl-res{color:var(--vscode-errorForeground);opacity:.9}
 .tl .tl-exp{flex-shrink:0;font-size:10px;font-family:"codicon";opacity:0;transition:opacity .12s,transform .15s;width:12px;color:var(--vscode-descriptionForeground);margin-left:2px;pointer-events:none}
 .tl.has-detail{cursor:pointer}
@@ -687,3 +692,38 @@ body.vscode-light .settings-test-result.ok{color:#267f26}
 .ft-ctx-pop-row b { font-weight: 600; font-variant-numeric: tabular-nums; }
 .ft-ctx-pop-tip { margin-top: 8px; padding-top: 8px; border-top: 1px dashed var(--vscode-widget-border, #3a3a3a); font-size: 11px; opacity: .85; }
 .ft-ctx-pop-tip code { background: var(--vscode-textCodeBlock-background, #1e1e1e); padding: 0 4px; border-radius: 3px; }
+
+/* ── Suppress red "failed" styling on tool cards / prose tool rows ──
+   User-requested: tool failures (e.g. skill_create failed, mkdir errors)
+   should not surface as alarming red blocks. We neutralise the icon /
+   status / border colours and the "failed" badge so failures blend with
+   normal tool output. The error text itself is still readable in the
+   expanded body. Top-level extension errors (`.err` standalone card,
+   chip-err in attachment list, settings test results) are intentionally
+   left untouched — those convey actionable problems the user must see. */
+.tool.err .h .ico { color: var(--vscode-descriptionForeground) !important; opacity: .7 !important; }
+.tl.err { background: transparent !important; border-left: none !important; border-radius: 2px !important; padding: 1px 2px !important; }
+.tl.err   .ico    { color: var(--vscode-descriptionForeground) !important; opacity: .7 !important; }
+.tl.err   .tl-res { color: var(--vscode-descriptionForeground) !important; opacity: .55 !important; }
+.tl-stream.done.err            { border-left-color: var(--vscode-panel-border) !important; }
+.tl-stream.done.err::before    { content: "done" !important; color: var(--vscode-descriptionForeground) !important; opacity: .55 !important; }
+
+/* ── Status dot: orange-pulsing while running → static green on success ──
+   The orange running dot is defined inline on `.tool.run .h .nm::after`
+   and `.tl.run .tl-res::before`. After completion the row swaps `.run`
+   for `.ok` (success) or `.err` (failure). Here we add a static green
+   dot on `.ok` so the user gets a clean "done" affordance. Failures
+   intentionally do NOT get a coloured dot — they remain neutral. */
+.tool.ok .h .nm::after {
+    content: ""; display: inline-block;
+    width: 5px; height: 5px; border-radius: 50%;
+    background: #7bc47f; margin-left: 5px;
+    vertical-align: middle; opacity: .85;
+}
+.tl.ok .tl-res::before {
+    content: ""; display: inline-block;
+    width: 5px; height: 5px; border-radius: 50%;
+    background: #7bc47f; margin-right: 4px;
+    vertical-align: middle; opacity: .85;
+}
+

--- a/media/chat.css
+++ b/media/chat.css
@@ -713,17 +713,14 @@ body.vscode-light .settings-test-result.ok{color:#267f26}
    and `.tl.run .tl-res::before`. After completion the row swaps `.run`
    for `.ok` (success) or `.err` (failure). Here we add a static green
    dot on `.ok` so the user gets a clean "done" affordance. Failures
-   intentionally do NOT get a coloured dot — they remain neutral. */
+   intentionally do NOT get a coloured dot — they remain neutral.
+   Note: the prose-row variant `.tl.ok .tl-res::before` is already defined
+   above near the running/error dots (Issue #162 Phase 1); only the card
+   variant `.tool.ok .h .nm::after` lives here. */
 .tool.ok .h .nm::after {
     content: ""; display: inline-block;
     width: 5px; height: 5px; border-radius: 50%;
     background: #7bc47f; margin-left: 5px;
-    vertical-align: middle; opacity: .85;
-}
-.tl.ok .tl-res::before {
-    content: ""; display: inline-block;
-    width: 5px; height: 5px; border-radius: 50%;
-    background: #7bc47f; margin-right: 4px;
     vertical-align: middle; opacity: .85;
 }
 

--- a/media/chat.js
+++ b/media/chat.js
@@ -2590,7 +2590,27 @@
           addToolCard(m.id, m.name, m.args);
         }
       } else {
-        addToolLine(m.id, m.name, m.args);
+        /* Issue #162 Phase 0: reuse the existing placeholder created by an
+           early toolArgsDelta (when the LLM streams `content` before `path`).
+           Without this, toolStart would insert a SECOND .tl-wrap and overwrite
+           toolMap[id] — orphaning the first row's _streamPre (stuck "streaming…"
+           forever) and producing a fileless "Edited" ghost line. */
+        var _existLine = toolMap.get(m.id);
+        if (_existLine && _existLine.isLine && _existLine.root) {
+          _existLine.name = m.name;
+          _existLine.args = m.args;
+          var _meta162 = toolMeta(m.name, m.args);
+          var _cls162 = (_existLine.root.className || "").split(/\s+/)
+            .filter(function(c){ return c && !/^k-/.test(c); });
+          _cls162.push("k-" + _meta162.kind);
+          _existLine.root.className = _cls162.join(" ");
+          var _ico162 = _existLine.root.querySelector(".ico");
+          if (_ico162) _ico162.className = "ico codicon " + _meta162.icon;
+          var _prose162 = _existLine.root.querySelector(".tl-prose");
+          if (_prose162) _prose162.innerHTML = toolProseHtml(m.name, m.args, _meta162);
+        } else {
+          addToolLine(m.id, m.name, m.args);
+        }
       }
     } else if (m.type === "approvalRequest"){
       addToolCard(m.id, m.name, m.args, { approval:true });
@@ -2747,8 +2767,8 @@
             tc.body.innerHTML = ""; tc.body.appendChild(outPre);
             tc.root.classList.add("has-detail");
             if (!tc._userToggled){
-              if (m.ok) { tc.root.classList.remove("open"); tc.body.style.display = "none"; }
-              else      { tc.root.classList.add("open");    tc.body.style.display = "block"; }
+              /* Always collapse on completion (success or failure). */
+              tc.root.classList.remove("open"); tc.body.style.display = "none";
             }
           } else if (tc.name === "spawn_agent" || m.name === "spawn_agent") {
             tc.body.innerHTML = renderMd(out);
@@ -2758,8 +2778,8 @@
             tc.body.textContent = out;
             tc.root.classList.add("has-detail");
             if (!tc._userToggled){
-              if (m.ok) { tc.root.classList.remove("open"); tc.body.style.display = "none"; }
-              else      { tc.root.classList.add("open");    tc.body.style.display = "block"; }
+              /* Always collapse on completion (success or failure). */
+              tc.root.classList.remove("open"); tc.body.style.display = "none";
             }
           }
         } else if (tc.name === "spawn_agent" || m.name === "spawn_agent") {
@@ -2780,15 +2800,15 @@
           outPre.textContent = stripAnsi(runShellBody);
           tc.body.appendChild(outPre);
           if (!tc._userToggled){
-            if (m.ok) tc.root.classList.remove("open");
-            else      tc.root.classList.add("open");
+            /* Always collapse on completion (success or failure). */
+            tc.root.classList.remove("open");
           }
         } else if (tc.name === "read_terminal" || m.name === "read_terminal") {
           /* Terminal poll: strip ANSI/progress-bar noise, keep collapsed on success */
           tc.body.textContent = stripAnsi(out);
           if (!tc._userToggled){
-            if (m.ok) tc.root.classList.remove("open");
-            else      tc.root.classList.add("open");
+            /* Always collapse on completion (success or failure). */
+            tc.root.classList.remove("open");
           }
           /* Refresh dedup map so the next poll can find this card */
           if (tc._rtKey) _readTermCardMap.set(tc._rtKey, tc);
@@ -2796,12 +2816,28 @@
           /* web_search: same rule as shell — collapse on success, expand on failure */
           tc.body.textContent = out;
           if (!tc._userToggled){
-            if (m.ok) tc.root.classList.remove("open");
-            else      tc.root.classList.add("open");
+            /* Always collapse on completion (success or failure). */
+            tc.root.classList.remove("open");
           }
         } else {
           tc.body.textContent = out;
           if (!tc._userToggled) tc.root.classList.remove("open");
+        }
+      }
+      /* Issue #162 Phase 2: relocate the live stream preview (`.tl-stream`) into
+         the detail pane on completion. Without this the preview stays inline
+         under the row forever, and visually nothing distinguishes a finished
+         write_file from an in-flight one. After the move the row collapses to a
+         single tidy line (matching read_file UX) and the user can click to
+         re-expand the patched content. */
+      if (tc.isLine && tc._streamPre && tc.body) {
+        if (tc._streamPre.parentNode !== tc.body) {
+          tc.body.appendChild(tc._streamPre);
+        }
+        tc.root.classList.add("has-detail");
+        if (!tc._userToggled) {
+          tc.root.classList.remove("open");
+          tc.body.style.display = "none";
         }
       }
       liveGroupCompleted();

--- a/media/chat.js
+++ b/media/chat.js
@@ -2788,9 +2788,10 @@
           if (!tc._userToggled) tc.root.classList.add("open");
         } else if (tc.name === "run_shell" || m.name === "run_shell") {
           /* Replace the streaming live tail with the final, complete output.
-             GH-Copilot behaviour: success → auto-collapse (header summary is
-             enough); failure → keep expanded so the error is immediately
-             visible.  Respect any prior manual user toggle.
+             Behaviour: always auto-collapse on completion (success or failure)
+             — the header summary plus the row-level status dot is enough; users
+             expand manually when they need to read full output. Respect any
+             prior manual user toggle.
              When shell.js returns a structured JSON object, show the human-readable
              `text` field rather than raw JSON. */
           if (tc._livePre){ tc._livePre.remove(); tc._livePre = null; }
@@ -2804,7 +2805,9 @@
             tc.root.classList.remove("open");
           }
         } else if (tc.name === "read_terminal" || m.name === "read_terminal") {
-          /* Terminal poll: strip ANSI/progress-bar noise, keep collapsed on success */
+          /* Terminal poll: strip ANSI/progress-bar noise; always collapse on
+             completion (success or failure) — matches the unified UX with
+             run_shell / web_search above. */
           tc.body.textContent = stripAnsi(out);
           if (!tc._userToggled){
             /* Always collapse on completion (success or failure). */
@@ -2813,7 +2816,7 @@
           /* Refresh dedup map so the next poll can find this card */
           if (tc._rtKey) _readTermCardMap.set(tc._rtKey, tc);
         } else if (tc.name === "web_search" || m.name === "web_search") {
-          /* web_search: same rule as shell — collapse on success, expand on failure */
+          /* web_search: same rule as shell — always collapse on completion (success or failure). */
           tc.body.textContent = out;
           if (!tc._userToggled){
             /* Always collapse on completion (success or failure). */
@@ -2830,7 +2833,7 @@
          write_file from an in-flight one. After the move the row collapses to a
          single tidy line (matching read_file UX) and the user can click to
          re-expand the patched content. */
-      if (tc.isLine && tc._streamPre && tc.body) {
+      if (tc.isLine && tc._streamPre && tc.body && tc.root) {
         if (tc._streamPre.parentNode !== tc.body) {
           tc.body.appendChild(tc._streamPre);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deep-copilot",
-  "version": "0.41.0",
+  "version": "0.41.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deep-copilot",
-      "version": "0.41.0",
+      "version": "0.41.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",
         "js-tiktoken": "^1.0.21",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deep-copilot",
   "displayName": "Deep Copilot",
   "description": "Deep Copilot — AI coding agent embedded in VS Code. Powered by DeepSeek V4, with file editing, terminal, search, and plan/todos. Standalone, no backend required.",
-  "version": "0.41.0",
+  "version": "0.41.6",
   "publisher": "ZhouChaunge",
   "icon": "imgs/logo.png",
   "repository": {


### PR DESCRIPTION
Closes #162

## 概要

本 PR 主要修复 Issue #162（write_file 流式工具行渲染状态错乱），同时顺手收口了一批本地早已经验证过、但仍未推到 main 的 webview UX 调整。维护者已确认本地状态即为期望状态，整体合入即可。

---

## 1. Issue #162 修复（主体）

连续多次触发 `write_file` 时，webview 的工具行渲染出现三个相关 bug：

1. 只有 **第一次** 编辑显示绿色 `done` 徽标，后续几次都没有
2. `.tl-stream` 实时预览块经常 **卡在 `streaming…`**，即使编辑早已结束
3. 完成后的 `Edited` 行 **不会自动折叠**，聊天历史越积越长

### 根本原因

当 LLM 把 `write_file` 参数按 `{"content":"...","path":"..."}` 顺序流式输出时，`ToolArgsStreamer.feed()` 会先发 `contentDelta` 再发 `newPath`：

- webview 收到 `toolArgsDelta` 时 `toolMap` 还没有该 id，fallback 调用 `addToolLine` 创建占位 `.tl-wrap` 并把 `_streamPre` 挂到它身上
- 随后真正的 `toolStart` 到达，`addToolLine` **无条件** 追加了第二个 `.tl-wrap`，并 `toolMap.set(id, …)` **覆盖** 占位条目
- 结果：占位行变成 DOM 孤儿（`.tl-stream` 永远拿不到 `done` class），新条目又没有 `_streamPre` 引用，所以 `toolResult` 跳过完成标记

此外，完成指示完全依赖 `.tl-stream::before` 这一个伪元素 —— 非流式 provider / 会话回放 / 字段顺序不利时根本不会创建 `.tl-stream`，绿色徽标就消失。

### 三步修复

- **Phase 0 — `media/chat.js` `toolStart` 复用占位行**：toolMap[id] 已存在占位时原地刷新 name / args / prose / icon / kind class，保留 `_streamPre` 与 DOM 位置；不再产生孤儿 `.tl-wrap`。
- **Phase 1 — `media/chat.css` 行级完成圆点**：新增 `.tl.ok .tl-res::before`（绿）/ `.tl.err .tl-res::before`（红）。无论是否触发流式预览路径，完成态都有稳定可视信号。
- **Phase 2 — `media/chat.js` `toolResult` 折叠**：完成时若仍有 `_streamPre`，搬入 `.tl-detail` body、加 `has-detail`、默认 collapse。完成的 Edited 行收成一行，点击可重新展开看 patch 内容（与 `read_file` UX 对齐）。

---

## 2. 一并随车的 webview UX 调整（本地已验证）

> 这些改动不是 Issue #162 必需的，但是本地长期使用确认过的优化，借这次 PR 把本地与 main 拉平。

- **`media/chat.js` `toolResult` 统一"成功失败都折叠"**：原先 `run_shell` / `web_search` / `read_terminal` 等在失败时 `add("open")` 强制展开，会把红色错误块整屏顶到聊天里造成干扰；改为完成态统一折叠，错误内容仍可点击展开查看。
- **`media/chat.css` 失败态去红化**：新增一组 `.tool.err` / `.tl.err` / `.tl-stream.done.err` 的中性化覆盖，把工具失败（例如 `skill_create` 失败、`mkdir` 报错）的红色块降级为普通灰色提示，避免恐慌感；扩展级真错误（`.err` 独立卡片、`.chip-err`、设置测试结果）保留红色。
- **`media/chat.css` 卡片完成圆点**：新增 `.tool.ok .h .nm::after` 绿点，让卡片型工具（与行型 Phase 1 对应）也有完成徽标。

---

## 3. 影响范围

- 仅触及 webview（`media/chat.js` + `media/chat.css`），无 extension host / provider / 协议变更
- 无新依赖
- 无 CSP / 安全相关改动
- 版本号 0.41.0 → 0.41.6（package.json + package-lock.json 同步）

## 4. 验证

- `npm run package` 通过，产物 `release/deep-copilot-0.41.6.vsix`（87 文件，6.32 MB）
- 静态检查对 `media/chat.js`、`media/chat.css` 均无新增告警（CSS 中预先存在的 Safari `user-select` 兼容警告与本次无关）
- 建议人工冒烟：连续触发 3-5 次 `write_file`，确认每行都出现绿色圆点、完成后自动折叠、无残留 `streaming…`；再触发一次失败的 shell / 工具，确认输出折叠且不刺眼。
