### PR TITLE
fix(archive): pure-export semantics + auto-unarchive migration (#169)

### DIFF
--- a/src/chat/agent-loop.js
+++ b/src/chat/agent-loop.js
@@ -282,6 +282,12 @@ class AgentLoop {
         // ctx.registerBgJob into bg-shell so each freshly started jobId is
         // recorded here; we clear entries on end so memory is bounded.
         run._sessionStartedBgJobs = new Set();
+        // Bg jobs the model has actively inspected via read_terminal in this run.
+        // Populated by tool-executor; consumed by the BG_WAIT_SKIPPED_MODEL_DONE
+        // guard so the turn refuses to end while a monitored job is still alive
+        // (e.g. user asked the model to watch a training that was started in an
+        // earlier turn — `_sessionStartedBgJobs` alone wouldn't catch this).
+        run._monitoredBgJobs = new Set();
         // Only accept job-end events for jobs that belong to THIS session.
         // Require an exact sessionId match so events without a sessionId (orphaned
         // terminals not registered via addActiveBgJob) are also dropped — this
@@ -289,7 +295,10 @@ class AgentLoop {
         const _bgJobEndHandler = (payload) => {
             if (!payload || payload.sessionId !== sid) return;
             run._pendingBgJobEvents.push(payload);
-            if (payload.jobId) run._sessionStartedBgJobs.delete(payload.jobId);
+            if (payload.jobId) {
+                run._sessionStartedBgJobs.delete(payload.jobId);
+                run._monitoredBgJobs.delete(payload.jobId);
+            }
         };
         onBgJobEnded(_bgJobEndHandler);
 
@@ -642,10 +651,21 @@ class AgentLoop {
                             const _activeJobsNow = myBgJobs();
                             const _hasOwnRunningJob = [...run._sessionStartedBgJobs]
                                 .some(j => _activeJobsNow.has(j));
-                            if (!_hasPendingEvents && !_hasOwnRunningJob) {
+                            // Watchdog scenario: model is actively monitoring a
+                            // pre-existing bg job (e.g. training started in an
+                            // earlier turn). Detected when the model has called
+                            // read_terminal(terminal: "deepseek-job-X") in this
+                            // run. If any such monitored job is still active,
+                            // refuse to end the turn — the model committed to
+                            // watching it through completion.
+                            const _monitored = (run._monitoredBgJobs instanceof Set) ? run._monitoredBgJobs : null;
+                            const _hasMonitoredRunningJob = !!_monitored && [..._monitored]
+                                .some(j => _activeJobsNow.has(j));
+                            if (!_hasPendingEvents && !_hasOwnRunningJob && !_hasMonitoredRunningJob) {
                                 Logger.info('BG_WAIT_SKIPPED_MODEL_DONE', {
                                     jobs: [..._activeJobsNow],
                                     sessionStartedJobs: [...run._sessionStartedBgJobs],
+                                    monitoredJobs: _monitored ? [..._monitored] : [],
                                 });
                                 break;
                             }

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -102,6 +102,40 @@ class SessionStore {
         this._getBusy    = getBusy;         // (id) => bool   (is that session's run busy?)
         this._onDeleteRun = onDeleteRun;    // (id) => void   (abort + remove from _runs)
         this.sessionId   = null;            // currently displayed session id (null = empty view)
+
+        // Issue #169: archive semantics changed from "soft-hide + export" to
+        // "pure export". Sessions that were previously hidden by the old
+        // archive action are stuck invisible in globalState. Run a one-shot
+        // idempotent migration that flips every `archived: true` back to
+        // `false` so those records reappear in the sidebar after upgrade.
+        // Guarded by a globalState boolean so we only do this once per user.
+        // Fire-and-forget: any postList() call after the next tick will see
+        // the migrated data.
+        this._migrateArchivedFlagIfNeeded();
+    }
+
+    /**
+     * One-time migration for issue #169. Idempotent: subsequent runs no-op
+     * because the `archiveSemanticsV2Migrated` flag is set on first success.
+     * Errors are swallowed (logged via console.warn) — failure here must not
+     * block extension activation.
+     */
+    async _migrateArchivedFlagIfNeeded() {
+        try {
+            if (this._gs.get('deepseekAgent.archiveSemanticsV2Migrated', false)) return;
+            const list = this.all();
+            let touched = false;
+            for (const s of list) {
+                if (s.archived) { s.archived = false; touched = true; }
+            }
+            if (touched) await this.set(list);
+            await this._gs.update('deepseekAgent.archiveSemanticsV2Migrated', true);
+            if (touched) this.postList();
+        } catch (err) {
+            // Non-fatal: next launch will retry.
+            // eslint-disable-next-line no-console
+            console.warn('[deep-copilot] archive-v2 migration failed:', err && err.message || err);
+        }
     }
 
     // ─── Raw storage ────────────────────────────────────────────────────────
@@ -361,43 +395,28 @@ class SessionStore {
     }
 
     /**
-     * "Archive" a session — issue #165.
+     * "Archive" a session — issues #165, #169.
      *
-     * Original behaviour (pre-#165) was a soft-hide toggle: flip `archived`,
-     * disappear from the sidebar list, data stays in globalState. Users
-     * reported that this didn't match the menu label's promise: nothing was
-     * actually *archived* anywhere they could see, find, or grep.
+     * Behaviour evolution:
+     *   pre-#165 : soft-hide toggle (flip `archived`, disappear from list).
+     *   #165/#166: render to Markdown + soft-hide (export AND hide).
+     *   #169     : pure export. Render to Markdown, leave session state
+     *              completely untouched — it stays in the sidebar, stays
+     *              the active session, can be archived again to produce
+     *              another snapshot.
      *
-     * New behaviour: render the session to Markdown and write it under
-     *   <workspace>/.deep-copilot/archives/yyyyMMdd-HHmmss-<title>.md
-     * Then perform the original soft-hide so the session leaves the sidebar.
+     * Contract:
+     *   - exportSessionToMarkdown returns absolute path → toast + done.
+     *   - returns null (user cancelled folder picker / save dialog) → silent.
+     *   - throws → toast error; no state change.
      *
-     * The "un-archive" gesture (clicking again on an already-archived item)
-     * is still supported via the boolean toggle — it simply un-hides the
-     * record without touching the Markdown file on disk.
+     * Session state (`archived` flag, current sessionId, list ordering) is
+     * never mutated by this method.
      */
     async archive(id) {
-        const list = this.all();
-        const s = list.find(x => x.id === id);
+        const s = this.all().find(x => x.id === id);
         if (!s) return;
 
-        // Un-archive: just flip back to visible. No file I/O needed.
-        if (s.archived) {
-            s.archived = false;
-            await this.set(list);
-            this.postList();
-            return;
-        }
-
-        // Archive: render to Markdown FIRST. Only hide the session from the
-        // sidebar if we actually produced a file on disk — otherwise setting
-        // `archived = true` on export failure (or on a user-cancelled save
-        // dialog) would leave the session invisible in the list while nothing
-        // was actually archived. Contract:
-        //   - savedPath is a string  → write succeeded, hide the session.
-        //   - savedPath is null      → user cancelled the save dialog; keep
-        //                              session visible, do nothing more.
-        //   - throw caught below     → fs error; surface message, keep visible.
         let savedPath = null;
         try {
             const { exportSessionToMarkdown } = require('./archive-export');
@@ -405,17 +424,9 @@ class SessionStore {
         } catch (err) {
             const msg = (err && err.message) || String(err);
             vscode.window.showErrorMessage(tf('archiveFailed', { msg }));
-            return; // do not toggle archived — keep state consistent
+            return;
         }
-        if (!savedPath) return; // user cancelled; keep state consistent
-
-        s.archived = true;
-        if (this.sessionId === id) {
-            this.sessionId = null;
-            this._post({ type: 'sessionLoaded', id: null, messages: [] });
-        }
-        await this.set(list);
-        this.postList();
+        if (!savedPath) return; // user cancelled
 
         this._notifyArchived(savedPath);
     }

--- a/src/chat/session-store.js
+++ b/src/chat/session-store.js
@@ -8,6 +8,7 @@
 const vscode = require('vscode');
 const { randomBytes } = require('crypto');
 const { t, tf } = require('../utils/i18n');
+const { Logger } = require('../logger');
 
 // ─── Orphan tool_calls sanitizer ───────────────────────────────────────────
 // Removes ANY incomplete assistant{tool_calls} group from a message array,
@@ -109,16 +110,19 @@ class SessionStore {
         // idempotent migration that flips every `archived: true` back to
         // `false` so those records reappear in the sidebar after upgrade.
         // Guarded by a globalState boolean so we only do this once per user.
-        // Fire-and-forget: any postList() call after the next tick will see
-        // the migrated data.
+        // Fire-and-forget: the migration runs asynchronously and triggers
+        // postList() itself once it finishes, so the sidebar refreshes as
+        // soon as the migrated data is persisted (not necessarily on the
+        // very next tick).
         this._migrateArchivedFlagIfNeeded();
     }
 
     /**
      * One-time migration for issue #169. Idempotent: subsequent runs no-op
      * because the `archiveSemanticsV2Migrated` flag is set on first success.
-     * Errors are swallowed (logged via console.warn) — failure here must not
-     * block extension activation.
+     * Errors are swallowed (logged via Logger) — failure here must not
+     * block extension activation; the next launch will retry automatically
+     * because the flag was never written.
      */
     async _migrateArchivedFlagIfNeeded() {
         try {
@@ -132,9 +136,13 @@ class SessionStore {
             await this._gs.update('deepseekAgent.archiveSemanticsV2Migrated', true);
             if (touched) this.postList();
         } catch (err) {
-            // Non-fatal: next launch will retry.
-            // eslint-disable-next-line no-console
-            console.warn('[deep-copilot] archive-v2 migration failed:', err && err.message || err);
+            // Non-fatal: next launch will retry. Route through Logger so the
+            // diagnostic respects deepseekAgent.enableDebugLog and lands in
+            // the "Deep Copilot Debug" output channel/log file.
+            Logger.info('ARCHIVE_V2_MIGRATION_FAILED', {
+                message: (err && err.message) || String(err),
+                stack:   (err && err.stack)   || undefined,
+            });
         }
     }
 

--- a/src/chat/tool-executor.js
+++ b/src/chat/tool-executor.js
@@ -532,6 +532,20 @@ class ToolExecutor {
                 if (!(run._sessionStartedBgJobs instanceof Set)) run._sessionStartedBgJobs = new Set();
                 run._sessionStartedBgJobs.add(jobId);
             };
+            // Watchdog/monitor detection: when the model inspects an existing
+            // deepseek-job-* terminal via read_terminal in this run, treat that
+            // as an active monitoring commitment. agent-loop's
+            // BG_WAIT_SKIPPED_MODEL_DONE guard refuses to end the turn while a
+            // monitored job is still alive — preventing the model from
+            // "promising to keep watching" and then immediately stopping when
+            // the underlying job was spawned in a previous turn.
+            if (name === 'read_terminal' && run && args && typeof args.terminal === 'string') {
+                const _jobId = args.terminal;
+                if (/^deepseek-job-/.test(_jobId)) {
+                    if (!(run._monitoredBgJobs instanceof Set)) run._monitoredBgJobs = new Set();
+                    run._monitoredBgJobs.add(_jobId);
+                }
+            }
             if (tcId) {
                 ctx.onStreamDelta = (delta) => {
                     if (!delta) return;


### PR DESCRIPTION
﻿Closes #169.

## 改动

本 PR 含两组改动：

### A. Archive 语义改为「纯导出」 (#169)

把 `Archive` 从「软隐藏 + 导出」改成「纯导出」。

- `src/chat/session-store.js` 中 `archive(id)`：
  - 删除 unarchive 分支（之前不可达）；
  - 删除 `s.archived = true` 写入；
  - 删除当前激活 session 被切走（`sessionId = null` + `sessionLoaded` 空消息广播）的副作用；
  - 删除写回 list 和 `postList()` 调用（不再有状态变更需要广播）；
  - 仅保留：调用 `exportSessionToMarkdown(s)` + 错误/取消处理 + `_notifyArchived(savedPath)`。
- `src/chat/session-store.js` 构造函数新增一次性迁移 `_migrateArchivedFlagIfNeeded()`：
  - 由 `globalState['deepseekAgent.archiveSemanticsV2Migrated']` 守护，幂等；
  - 把所有 `archived: true` 翻回 `false`；
  - 迁移失败走 `Logger.info('ARCHIVE_V2_MIGRATION_FAILED', ...)`，不阻塞激活；
  - 仅当真有 session 被翻转时才调 `postList()`，避免无谓刷新。

注意：`session-store.js#L125` 的 `.filter(s => !s.archived)` 和 `provider.js#L208` 的 `find(s => !s.archived)` **保留**，作为向后兼容。迁移完成后所有记录都 `archived = false`，过滤器自然变成 no-op。后续 minor 版本可移除字段。

### B. Watchdog 任务不再提前结束会话

模型在执行「值守」类任务（例如长时间训练）时，如果 bg job 是在更早的轮次启动的，`run._sessionStartedBgJobs` 在当前 run 是空集，`BG_WAIT_SKIPPED_MODEL_DONE` 守卫就会在模型刚说完「我会持续监控」之后立刻结束 turn，把值守静默掐断。

- `src/chat/tool-executor.js`：当模型调用 `read_terminal(terminal: "deepseek-job-*")` 时，把该 jobId 记入 `run._monitoredBgJobs`，作为「当前 run 在主动监控该任务」的信号。
- `src/chat/agent-loop.js`：
  - 初始化 `run._monitoredBgJobs = new Set()`；
  - bg job 结束事件同步清理该集合；
  - `BG_WAIT_SKIPPED_MODEL_DONE` 守卫新增 `_hasMonitoredRunningJob` 条件 —— 任何被监控且仍活着的 bg job 都会阻止 turn 提前退出，循环继续走 4 分钟快照 / 等结束事件，直到任务完成或命中 4h 本轮预算。

## 使用场景对比

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 点存档 | 写 md + session 消失 | 写 md + session 保持原状 |
| 同一 session 连点 2 次 | 第二次取消存档（session 回来） | 生成 2 个 md，session 保持原状 |
| 取消保存对话框 | session 不动 | session 不动（不变） |
| 写盘失败 | toast 报错，session 不动 | toast 报错，session 不动（不变） |
| 升级到带本 PR 的版本 | — | 旧版本被存档的所有 session 自动回到列表 |
| 模型值守跨 turn 的训练 | 模型说完「我会监控」立刻退出 turn | 只要 read_terminal 过该 bg job 且任务仍在跑，turn 持续等待 |

## 测试

- `npm run build` ✅。
- `npm run lint` ✅ 0 errors（warnings 全是仓库现存的 indent 风格告警，未在本次新增）。
- 手工核查 `archive()` 路径：导出成功 → toast；导出取消 → 静默；导出抛错 → toast；任何分支都不再改动 session state。
- 手工核查迁移：第一次运行清零 `archived` 字段并写 flag；第二次进入即 short-circuit；失败路径走 `Logger.info`。
- 手工核查 watchdog：bg job 在前一个 turn 启动，本 turn 调用过 `read_terminal(deepseek-job-X)` 后，模型即便给出最终回复也不会触发 `BG_WAIT_SKIPPED_MODEL_DONE`，循环继续。

## 兼容性 / 风险

- 不破坏数据 schema：`archived` 字段保留，迁移只翻值。
- 旧的 `.deep-copilot/archives/*.md` 文件原封不动。
- 仅一个可观察行为变化：升级后曾经被「藏起来」的 session 全部回到侧边栏。需要在 release notes 写一句迁移提示。
- Watchdog 改动只放宽提前退出条件，不改变正常 turn 结束语义；模型从未 `read_terminal` 过的 bg job（例如旁路 dev server）依然走老的 short-circuit。

## 关联

- Issue #169
- 衍生自 #165 / PR #166 的语义讨论。
