### PR TITLE
fix: move session controls to dedicated #topbar, restore #sb as notif…

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -71,7 +71,7 @@ const extConfig = {
     bundle: true,
     platform: 'node',
     target: 'node18',
-    external: ['vscode'],
+    external: ['vscode', 'js-tiktoken'],
     format: 'cjs',
     minify: isProd,
     sourcemap: !isProd,

--- a/media/chat.css
+++ b/media/chat.css
@@ -276,7 +276,6 @@ html[data-locale="en"] body{font-family:"Segoe UI","Inter",system-ui,-apple-syst
 #right .si .busy-dot{display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--vscode-button-background,#4ea1ff);margin-right:6px;vertical-align:middle;animation:sibusy 1s ease-in-out infinite}
 @keyframes sibusy{0%,100%{opacity:.35;transform:scale(.85)}50%{opacity:1;transform:scale(1.15)}}
 #ia{grid-area:composer;padding:8px 24px;background:var(--vscode-sideBar-background)}
-body.narrow #ia{padding-left:8px;padding-right:8px}
 #cxb{display:none;font-size:11px;color:var(--vscode-button-background);padding:0 2px 6px}
 /* @file attachment chips */
 #at-chips{display:none;flex-wrap:wrap;gap:4px;padding:6px 10px 2px;max-width:100%}

--- a/media/chat.css
+++ b/media/chat.css
@@ -15,16 +15,16 @@ html[data-locale="en"] body{font-family:"Segoe UI","Inter",system-ui,-apple-syst
 .tbb{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:3px 8px;border-radius:3px;font-size:11px}
 .tbb:hover{background:var(--vscode-toolbar-hoverBackground)}
 .tbb.active{color:var(--vscode-button-background)}
-/* ── Top bar: always-visible session controls ── */
-#topbar{grid-area:topbar;display:flex;align-items:center;justify-content:flex-end;padding:0 8px;height:36px;flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);background:var(--vscode-titleBar-activeBackground,var(--vscode-sideBar-background))}
+/* ── Top bar: always-visible session controls (kept above the drawer overlay) ── */
+#topbar{grid-area:topbar;position:relative;z-index:201;display:flex;align-items:center;justify-content:flex-end;padding:0 8px;height:36px;flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);background:var(--vscode-titleBar-activeBackground,var(--vscode-sideBar-background))}
 #sb-sessions-btn,#sb-new-btn{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:5px 7px;border-radius:5px;display:flex;align-items:center;justify-content:center;opacity:.8;font-size:16px}
 #sb-sessions-btn:hover,#sb-new-btn:hover{opacity:1;background:var(--vscode-toolbar-hoverBackground)}
 /* ── #sb: notification bar (hidden by default, shown by backend status messages) ── */
 #sb{grid-area:sb;font-size:11px;color:var(--vscode-descriptionForeground);background:rgba(244,135,113,.1);border-bottom:1px solid var(--vscode-panel-border);display:none;align-items:center;padding:4px 12px}
-/* ── Session drawer (always overlay, never in grid) ── */
-#right{display:none;position:fixed;right:0;top:0;bottom:0;z-index:200;width:280px;flex-direction:column;border-left:1px solid var(--vscode-panel-border);background:var(--vscode-sideBar-background);box-shadow:-4px 0 16px rgba(0,0,0,.25)}
+/* ── Session drawer (always overlay, never in grid; sits below #topbar) ── */
+#right{display:none;position:fixed;right:0;top:36px;bottom:0;z-index:200;width:280px;flex-direction:column;border-left:1px solid var(--vscode-panel-border);background:var(--vscode-sideBar-background);box-shadow:-4px 0 16px rgba(0,0,0,.25)}
 #right.drawer-open{display:flex}
-#session-backdrop{display:none;position:fixed;inset:0;z-index:199;background:rgba(0,0,0,.35);cursor:pointer}
+#session-backdrop{display:none;position:fixed;left:0;right:0;top:36px;bottom:0;z-index:199;background:rgba(0,0,0,.35);cursor:pointer}
 #session-backdrop.open{display:block}
 #main{grid-area:main;overflow-y:auto;padding:10px 24px;display:flex;flex-direction:column;gap:12px;min-height:0}
 .msgU{background:rgba(128,128,128,.18);outline:1px solid transparent;border-radius:8px 8px 2px 8px;padding:8px 12px;align-self:flex-end;max-width:88%;word-break:break-word;line-height:1.5;position:relative;cursor:pointer;transition:outline-color .15s,background .15s}

--- a/media/chat.css
+++ b/media/chat.css
@@ -17,7 +17,7 @@ html[data-locale="en"] body{font-family:"Segoe UI","Inter",system-ui,-apple-syst
 .tbb.active{color:var(--vscode-button-background)}
 /* ── Top bar: always-visible session controls ── */
 #topbar{grid-area:topbar;display:flex;align-items:center;justify-content:flex-end;padding:0 8px;height:36px;flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);background:var(--vscode-titleBar-activeBackground,var(--vscode-sideBar-background))}
-#sb-sessions-btn,#sb-new-btn{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:5px 7px;border-radius:5px;display:flex;align-items:center;justify-content:center;opacity:.8}
+#sb-sessions-btn,#sb-new-btn{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:5px 7px;border-radius:5px;display:flex;align-items:center;justify-content:center;opacity:.8;font-size:16px}
 #sb-sessions-btn:hover,#sb-new-btn:hover{opacity:1;background:var(--vscode-toolbar-hoverBackground)}
 /* ── #sb: notification bar (hidden by default, shown by backend status messages) ── */
 #sb{grid-area:sb;font-size:11px;color:var(--vscode-descriptionForeground);background:rgba(244,135,113,.1);border-bottom:1px solid var(--vscode-panel-border);display:none;align-items:center;padding:4px 12px}

--- a/media/chat.css
+++ b/media/chat.css
@@ -1,21 +1,10 @@
 ﻿*{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-foreground);background:var(--vscode-sideBar-background);height:100vh;overflow:hidden;position:relative;
-  display:grid;grid-template-columns:1fr 280px;grid-template-rows:auto 1fr auto auto;
-  grid-template-areas:"sb sb" "main right" "composer right" "foot foot"}
+  display:grid;grid-template-columns:1fr;grid-template-rows:auto auto 1fr auto auto;
+  grid-template-areas:"topbar" "sb" "main" "composer" "foot"}
 /* ── Locale-aware fonts ── */
 html[data-locale="zh"] body{font-family:"Microsoft YaHei UI","Microsoft YaHei","PingFang SC","Hiragino Sans GB","Noto Sans CJK SC","Source Han Sans CN","WenQuanYi Micro Hei",sans-serif}
 html[data-locale="en"] body{font-family:"Segoe UI","Inter",system-ui,-apple-system,BlinkMacSystemFont,"Helvetica Neue",Arial,sans-serif}
-body.no-right{grid-template-columns:1fr 0}
-body.no-right #right{display:none}
-body.no-right{grid-template-columns:1fr 0}
-body.narrow{grid-template-columns:1fr;grid-template-areas:"sb" "main" "composer" "foot"}
-body.narrow #right{display:none}
-/* CSS-only fallback: force narrow layout when webview viewport < 600px (independent of JS) */
-@media (max-width: 599px){
-  body{grid-template-columns:1fr !important;grid-template-areas:"sb" "main" "composer" "foot" !important}
-  body #right{display:none !important}
-  .edge-toggle{display:none !important}
-}
 #tb{display:none}
 #tb .logo{flex:1;font-size:12px;font-weight:600;display:flex;align-items:center;gap:8px}
 #tb .logo-img{width:22px;height:22px;display:block;opacity:1;border-radius:4px;background:transparent}
@@ -26,19 +15,18 @@ body.narrow #right{display:none}
 .tbb{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:3px 8px;border-radius:3px;font-size:11px}
 .tbb:hover{background:var(--vscode-toolbar-hoverBackground)}
 .tbb.active{color:var(--vscode-button-background)}
-#sb{grid-area:sb;padding:4px 12px;font-size:11px;color:var(--vscode-descriptionForeground);background:rgba(244,135,113,.1);border-bottom:1px solid var(--vscode-panel-border);display:none}
-/* Edge toggle buttons: half-circle pill on left/right edge to expand/collapse side panels */
-.edge-toggle{position:fixed;top:50%;transform:translateY(-50%);width:20px;height:64px;border:1px solid rgba(127,127,127,.55);background:rgba(127,127,127,.22);color:var(--vscode-foreground);font-size:13px;font-weight:600;line-height:64px;text-align:center;cursor:pointer;padding:0;z-index:50;opacity:.85;box-shadow:0 0 0 1px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.18);transition:opacity .15s,background .15s,border-color .15s,transform .15s,left .25s,right .25s;display:flex;align-items:center;justify-content:center}
-.edge-toggle:hover{opacity:1;background:rgba(127,127,127,.42);border-color:rgba(127,127,127,.95);color:var(--vscode-foreground)}
-.edge-toggle:active{background:rgba(127,127,127,.55)}
-.edge-toggle.edge-r{right:0;border-right:none;border-radius:14px 0 0 14px}
-.edge-toggle::before{content:"";font-family:"Segoe UI Symbol",sans-serif}
-body.no-right .edge-toggle.edge-r::before{content:"\25C2"} /* ◂ expand (point inward) */
-body:not(.no-right) .edge-toggle.edge-r{right:280px}
-body:not(.no-right) .edge-toggle.edge-r::before{content:"\25B8"} /* ▸ collapse */
-body.narrow .edge-toggle{display:none}
+/* ── Top bar: always-visible session controls ── */
+#topbar{grid-area:topbar;display:flex;align-items:center;justify-content:flex-end;padding:0 8px;height:36px;flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);background:var(--vscode-titleBar-activeBackground,var(--vscode-sideBar-background))}
+#sb-sessions-btn,#sb-new-btn{background:none;border:none;cursor:pointer;color:var(--vscode-icon-foreground);padding:5px 7px;border-radius:5px;display:flex;align-items:center;justify-content:center;opacity:.8}
+#sb-sessions-btn:hover,#sb-new-btn:hover{opacity:1;background:var(--vscode-toolbar-hoverBackground)}
+/* ── #sb: notification bar (hidden by default, shown by backend status messages) ── */
+#sb{grid-area:sb;font-size:11px;color:var(--vscode-descriptionForeground);background:rgba(244,135,113,.1);border-bottom:1px solid var(--vscode-panel-border);display:none;align-items:center;padding:4px 12px}
+/* ── Session drawer (always overlay, never in grid) ── */
+#right{display:none;position:fixed;right:0;top:0;bottom:0;z-index:200;width:280px;flex-direction:column;border-left:1px solid var(--vscode-panel-border);background:var(--vscode-sideBar-background);box-shadow:-4px 0 16px rgba(0,0,0,.25)}
+#right.drawer-open{display:flex}
+#session-backdrop{display:none;position:fixed;inset:0;z-index:199;background:rgba(0,0,0,.35);cursor:pointer}
+#session-backdrop.open{display:block}
 #main{grid-area:main;overflow-y:auto;padding:10px 24px;display:flex;flex-direction:column;gap:12px;min-height:0}
-body.narrow #main{padding-left:12px;padding-right:12px}
 .msgU{background:rgba(128,128,128,.18);outline:1px solid transparent;border-radius:8px 8px 2px 8px;padding:8px 12px;align-self:flex-end;max-width:88%;word-break:break-word;line-height:1.5;position:relative;cursor:pointer;transition:outline-color .15s,background .15s}
 .msgU-hd{display:none}
 .msgU-body{white-space:pre-wrap;word-break:break-word;line-height:1.5;pointer-events:none}
@@ -235,7 +223,6 @@ body.narrow #main{padding-left:12px;padding-right:12px}
 .tl-group.open .tl-list{display:flex;flex-direction:column;max-height:200px;overflow-y:auto}
 .err{color:var(--vscode-errorForeground);font-size:12px;padding:6px 10px;background:rgba(244,135,113,.08);border-radius:6px;border-left:3px solid var(--vscode-errorForeground);align-self:flex-start;width:100%;white-space:pre-wrap}
 #left{grid-area:left;display:flex;flex-direction:column;border-right:1px solid var(--vscode-panel-border);overflow:hidden;min-width:0;background:var(--vscode-sideBar-background)}
-#right{grid-area:right;display:flex;flex-direction:column;border-left:1px solid var(--vscode-panel-border);overflow:hidden;min-width:0;background:var(--vscode-sideBar-background)}
 .pnl{display:flex;flex-direction:column;border-bottom:1px solid var(--vscode-panel-border);min-height:0;flex:1 1 0}
 .pnl.pnl-mini{flex:0 0 auto}
 .pnl[data-open="0"]{flex:0 0 auto}

--- a/media/chat.js
+++ b/media/chat.js
@@ -312,8 +312,11 @@
   if (sbNewBtn) sbNewBtn.addEventListener('click', function() { newSession(); });
   if (sessionBackdrop) sessionBackdrop.addEventListener('click', closeSessionDrawer);
   if (rightPanel) rightPanel.addEventListener('click', function(e) {
-    var si = e.target.closest('.si');
-    if (si && si.dataset.id) closeSessionDrawer();
+    var target = e.target;
+    var si = target.closest('.si');
+    if (!si || !si.dataset.id) return;
+    if (target.closest('.si-rename-inp, input, textarea, select, button, a, label, [contenteditable="true"], [contenteditable=""], [contenteditable]')) return;
+    closeSessionDrawer();
   });
   /* Todo popup close button */
   var todoPopCloseBtn = document.getElementById("todo-pop-close");

--- a/media/chat.js
+++ b/media/chat.js
@@ -302,6 +302,7 @@
   function openSessionDrawer() {
     if (rightPanel) rightPanel.classList.add('drawer-open');
     if (sessionBackdrop) sessionBackdrop.classList.add('open');
+    if (sbSessionsBtn) sbSessionsBtn.setAttribute('aria-expanded', 'true');
     try { _drawerPrevFocus = document.activeElement; } catch(e){ _drawerPrevFocus = null; }
     if (rightPanel) {
       var focusTarget = rightPanel.querySelector('input, textarea, select, button, [tabindex]:not([tabindex="-1"]), a[href]');
@@ -313,6 +314,7 @@
   function closeSessionDrawer() {
     if (rightPanel) rightPanel.classList.remove('drawer-open');
     if (sessionBackdrop) sessionBackdrop.classList.remove('open');
+    if (sbSessionsBtn) sbSessionsBtn.setAttribute('aria-expanded', 'false');
     if (_drawerPrevFocus && typeof _drawerPrevFocus.focus === 'function') {
       try { _drawerPrevFocus.focus(); } catch(e){}
     }
@@ -325,6 +327,7 @@
   if (sessionBackdrop) sessionBackdrop.addEventListener('click', closeSessionDrawer);
   if (rightPanel) rightPanel.addEventListener('click', function(e) {
     var target = e.target;
+    if (!target || typeof target.closest !== 'function') return;
     var si = target.closest('.si');
     if (!si || !si.dataset.id) return;
     if (target.closest('.si-rename-inp, input, textarea, select, button, a, label, [contenteditable="true"], [contenteditable=""], [contenteditable]')) return;

--- a/media/chat.js
+++ b/media/chat.js
@@ -8,8 +8,6 @@
   var sbtn = document.getElementById("sbtn");
   var es   = document.getElementById("es");
   var apibt = document.getElementById("apibt");
-  var edgeL = document.getElementById("edgeL");
-  var edgeR = document.getElementById("edgeR");
   var newSessionBtn = document.getElementById("newSessionBtn");
   var scopeWs = document.getElementById("scopeWs");
   var scopeAll = document.getElementById("scopeAll");
@@ -294,29 +292,28 @@
     else jumpBtn.classList.add("show");
   }
 
-  /* Auto narrow mode based on width (use webview container width, not full VS Code window) */
-  function checkNarrow(){
-    var w = document.documentElement.clientWidth || window.innerWidth;
-    document.body.classList.toggle("narrow", w < 600);
+  /* ── Session drawer ── */
+  var sbSessionsBtn   = document.getElementById('sb-sessions-btn');
+  var sbNewBtn        = document.getElementById('sb-new-btn');
+  var sessionBackdrop = document.getElementById('session-backdrop');
+  var rightPanel      = document.getElementById('right');
+
+  function openSessionDrawer() {
+    if (rightPanel) rightPanel.classList.add('drawer-open');
+    if (sessionBackdrop) sessionBackdrop.classList.add('open');
   }
-  window.addEventListener("resize", checkNarrow);
-  if (typeof ResizeObserver !== "undefined") {
-    try { new ResizeObserver(checkNarrow).observe(document.documentElement); } catch(e){}
+  function closeSessionDrawer() {
+    if (rightPanel) rightPanel.classList.remove('drawer-open');
+    if (sessionBackdrop) sessionBackdrop.classList.remove('open');
   }
-  checkNarrow();
-  /* Edge toggles: right panel only (left panel removed). */
-  var _ui = {};
-  try { _ui = (vscode.getState() && vscode.getState().ui) || {}; } catch(e){}
-  function applyPanelState(){
-    document.body.classList.toggle("no-right", _ui.rightCollapsed !== false);
-  }
-  function savePanelState(){
-    try { var s = vscode.getState() || {}; s.ui = _ui; vscode.setState(s); } catch(e){}
-  }
-  applyPanelState();
-  if (edgeR) edgeR.addEventListener("click", function(){
-    _ui.rightCollapsed = !document.body.classList.contains("no-right");
-    applyPanelState(); savePanelState();
+  if (sbSessionsBtn) sbSessionsBtn.addEventListener('click', function() {
+    rightPanel && rightPanel.classList.contains('drawer-open') ? closeSessionDrawer() : openSessionDrawer();
+  });
+  if (sbNewBtn) sbNewBtn.addEventListener('click', function() { newSession(); });
+  if (sessionBackdrop) sessionBackdrop.addEventListener('click', closeSessionDrawer);
+  if (rightPanel) rightPanel.addEventListener('click', function(e) {
+    var si = e.target.closest('.si');
+    if (si && si.dataset.id) closeSessionDrawer();
   });
   /* Todo popup close button */
   var todoPopCloseBtn = document.getElementById("todo-pop-close");

--- a/media/chat.js
+++ b/media/chat.js
@@ -297,14 +297,26 @@
   var sbNewBtn        = document.getElementById('sb-new-btn');
   var sessionBackdrop = document.getElementById('session-backdrop');
   var rightPanel      = document.getElementById('right');
+  var _drawerPrevFocus = null;
 
   function openSessionDrawer() {
     if (rightPanel) rightPanel.classList.add('drawer-open');
     if (sessionBackdrop) sessionBackdrop.classList.add('open');
+    try { _drawerPrevFocus = document.activeElement; } catch(e){ _drawerPrevFocus = null; }
+    if (rightPanel) {
+      var focusTarget = rightPanel.querySelector('input, textarea, select, button, [tabindex]:not([tabindex="-1"]), a[href]');
+      if (focusTarget && typeof focusTarget.focus === 'function') {
+        try { focusTarget.focus(); } catch(e){}
+      }
+    }
   }
   function closeSessionDrawer() {
     if (rightPanel) rightPanel.classList.remove('drawer-open');
     if (sessionBackdrop) sessionBackdrop.classList.remove('open');
+    if (_drawerPrevFocus && typeof _drawerPrevFocus.focus === 'function') {
+      try { _drawerPrevFocus.focus(); } catch(e){}
+    }
+    _drawerPrevFocus = null;
   }
   if (sbSessionsBtn) sbSessionsBtn.addEventListener('click', function() {
     rightPanel && rightPanel.classList.contains('drawer-open') ? closeSessionDrawer() : openSessionDrawer();
@@ -317,6 +329,12 @@
     if (!si || !si.dataset.id) return;
     if (target.closest('.si-rename-inp, input, textarea, select, button, a, label, [contenteditable="true"], [contenteditable=""], [contenteditable]')) return;
     closeSessionDrawer();
+  });
+  /* Close drawer on Escape for keyboard accessibility */
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && rightPanel && rightPanel.classList.contains('drawer-open')) {
+      closeSessionDrawer();
+    }
   });
   /* Todo popup close button */
   var todoPopCloseBtn = document.getElementById("todo-pop-close");

--- a/src/webview/html.js
+++ b/src/webview/html.js
@@ -65,18 +65,8 @@ function buildWebviewHtml(webview, extensionUri) {
 <!-- #cbt kept hidden: chat.js references it for /clear command & Ctrl+K shortcut -->
 <button id="cbt" style="display:none" aria-hidden="true"></button>
 <div id="topbar">
-  <button id="sb-sessions-btn" title="${ui.sessions}" aria-label="Session history">
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="1" y="3" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="1" y="7" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="1" y="11" width="10" height="2" rx="1" fill="currentColor"/>
-    </svg>
-  </button>
-  <button id="sb-new-btn" title="${ui.newSession}" aria-label="New session">
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M8 2v12M2 8h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-    </svg>
-  </button>
+  <button id="sb-sessions-btn" title="${ui.sessions}" aria-label="Session history"><i class="codicon codicon-history"></i></button>
+  <button id="sb-new-btn" title="${ui.newSession}" aria-label="New session"><i class="codicon codicon-comment-add"></i></button>
 </div>
 <div id="sb"></div>
 <div id="main">

--- a/src/webview/html.js
+++ b/src/webview/html.js
@@ -157,7 +157,7 @@ function buildWebviewHtml(webview, extensionUri) {
     <span class="pill" id="ft-balance" title="${ui.balanceTitle}" style="display:none">${ui.balanceInit}</span>
   </div>
 </div>
-<!-- ── Session drawer backdrop (narrow mode) ── -->
+<!-- ── Session drawer backdrop (always-overlay drawer) ── -->
 <div id="session-backdrop"></div>
 <!-- ── Settings Modal ── -->
 <div id="settings-overlay" class="settings-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="settings-title">

--- a/src/webview/html.js
+++ b/src/webview/html.js
@@ -64,7 +64,20 @@ function buildWebviewHtml(webview, extensionUri) {
 <div id="prog" class="prog"></div>
 <!-- #cbt kept hidden: chat.js references it for /clear command & Ctrl+K shortcut -->
 <button id="cbt" style="display:none" aria-hidden="true"></button>
-<button id="edgeR" class="edge-toggle edge-r" title="${ui.sessions}" aria-label="toggle right panel"></button>
+<div id="topbar">
+  <button id="sb-sessions-btn" title="${ui.sessions}" aria-label="Session history">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="1" y="3" width="14" height="2" rx="1" fill="currentColor"/>
+      <rect x="1" y="7" width="14" height="2" rx="1" fill="currentColor"/>
+      <rect x="1" y="11" width="10" height="2" rx="1" fill="currentColor"/>
+    </svg>
+  </button>
+  <button id="sb-new-btn" title="${ui.newSession}" aria-label="New session">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 2v12M2 8h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    </svg>
+  </button>
+</div>
 <div id="sb"></div>
 <div id="main">
   <div id="es">
@@ -154,6 +167,8 @@ function buildWebviewHtml(webview, extensionUri) {
     <span class="pill" id="ft-balance" title="${ui.balanceTitle}" style="display:none">${ui.balanceInit}</span>
   </div>
 </div>
+<!-- ── Session drawer backdrop (narrow mode) ── -->
+<div id="session-backdrop"></div>
 <!-- ── Settings Modal ── -->
 <div id="settings-overlay" class="settings-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="settings-title">
   <div class="settings-modal">

--- a/src/webview/html.js
+++ b/src/webview/html.js
@@ -65,8 +65,8 @@ function buildWebviewHtml(webview, extensionUri) {
 <!-- #cbt kept hidden: chat.js references it for /clear command & Ctrl+K shortcut -->
 <button id="cbt" style="display:none" aria-hidden="true"></button>
 <div id="topbar">
-  <button id="sb-sessions-btn" title="${ui.sessions}" aria-label="Session history"><i class="codicon codicon-history"></i></button>
-  <button id="sb-new-btn" title="${ui.newSession}" aria-label="New session"><i class="codicon codicon-comment-add"></i></button>
+  <button id="sb-sessions-btn" title="${ui.sessions}" aria-label="${ui.sessions}" aria-controls="right" aria-expanded="false"><i class="codicon codicon-history"></i></button>
+  <button id="sb-new-btn" title="${ui.newSession}" aria-label="${ui.newSession}"><i class="codicon codicon-comment-add"></i></button>
 </div>
 <div id="sb"></div>
 <div id="main">


### PR DESCRIPTION
…ication bar

<!-- 请按下方模板填写，Copilot / DeepSeek 审核机器人会读取这部分内容 -->

## 变更说明 / Summary
<!-- 这次 PR 做了什么？为什么要做？-->

在插件顶部新增始终可见的工具栏（#topbar），包含会话历史（≡）和新建会话（+）两个按钮。点击 ≡ 可从右侧滑出完整的会话列表抽屉，支持搜索、切换工作区范围、新建会话等全部功能；点击空白处或选择会话后自动关闭。同时将会话列表（#right）从 grid 布局中完全移除，改为 position:fixed 的 overlay，不占用主聊天区空间。移除了所有 edge toggle 箭头按钮及其相关 CSS/JS（edgeR、applyPanelState、savePanelState、checkNarrow）。根本 bug 修复：原 #sb 元素是后端状态通知栏，JS 会将其隐藏，将按钮从 #sb 迁移至独立的 #topbar 后按钮不再消失。

## 变更类型 / Type of change
- [ ] Bug 修复
- [x] 新功能
- [x] 重构 / 性能优化
- [ ] 文档 / 注释
- [ ] CI / 构建脚本
- [] 其他：

## 影响范围 / Affected areas
- [ ] `src/api/**`（DeepSeek 接入）
- [ ] `src/chat/**`（对话核心）
- [x] `src/tools/**`（工具执行，安全敏感）
- [x] `src/webview/**`（UI）
- [ ] `src/prompts/**`
- [ ] `package.json` / 依赖
- [ ] CI / `.github/**`
- [x] 其他：media/chat.js · media/chat.css · esbuild.config.js

## 自检 / Checklist
- [x] 本地手动跑过受影响功能
- [x] 没有引入新的安全风险（密钥、命令注入、路径穿越）
- [x] 没有写入个人 / 测试用 API key
- [x] 修改的 webview 资源遵守了 CSP
- [ ] 必要时已更新 README / Release Notes

## 截图 / 录屏（可选）

https://github.com/user-attachments/assets/35a9a17a-803c-460f-9245-f03036ca070e

## 关联 Issue
Closes #127 
